### PR TITLE
fix: prevent window jumping to bottom when updating artwork

### DIFF
--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { Game, gameArt } from '../../../../shared/types/game.type';
 
 import { LibraryService } from '../../../../shared/services/library.service';
@@ -11,13 +11,23 @@ import { SlicePipe } from '@angular/common';
   templateUrl: './gamecard.component.html',
   styleUrl: './gamecard.component.scss',
 })
-export class GamecardComponent {
+export class GamecardComponent implements OnChanges {
   @Input() game: Game | undefined;
 
   constructor(public readonly _libraryService: LibraryService) {}
 
   public coverArt: gameArt | undefined;
   ngOnInit() {
+    this.updateCoverArt();
+  }
+
+  ngOnChanges(changes: SimpleChanges) {
+    if (changes['game']) {
+      this.updateCoverArt();
+    }
+  }
+
+  private updateCoverArt() {
     if (this.game && Array.isArray(this.game.art)) {
       this.coverArt = this.game.art.find((a) => a.type === 'COV');
     }

--- a/angular/src/app/pages/library/library.component.html
+++ b/angular/src/app/pages/library/library.component.html
@@ -54,7 +54,7 @@
       grid-auto-rows: minmax(auto, 200px);
     "
   >
-    @for (item of visibleGames$ | async; track item) {
+    @for (item of visibleGames$ | async; track item.gameId) {
     <app-gamecard [game]="item" class="h-full max-h-[200px]"></app-gamecard>
     }
   </div>

--- a/angular/src/app/shared/services/library.service.ts
+++ b/angular/src/app/shared/services/library.service.ts
@@ -413,11 +413,35 @@ export class LibraryService {
     this.setCurrentAction('Downloading Art for ' + gameId + '...');
     return window.libraryAPI
       .downloadArtByGameId(`${this.currentDirectory}/ART`, gameId, system)
-      .then((res) => {
+      .then(async (res) => {
         this.setCurrentAction('');
         this.setLoading(false);
-        this.refreshGamesFiles();
+        // Update only the affected game's artwork instead of refreshing
+        // the entire library, which would reset the scroll position.
+        await this.updateArtForGame(gameId);
       });
+  }
+
+  /**
+   * Re-reads artwork for a single game and patches it into the current
+   * library state without replacing the whole list, preserving scroll position.
+   */
+  private async updateArtForGame(gameId: string) {
+    if (!this.currentDirectory) return;
+    const artFiles = await this.parseArtFiles(this.currentDirectory);
+    const currentLibrary = this.librarySubject.getValue();
+    const updatedLibrary = currentLibrary.map((game) => {
+      if (game.gameId === gameId) {
+        return {
+          ...game,
+          art: artFiles
+            .filter((art: any) => art.gameId === gameId)
+            .map((art: any) => art),
+        };
+      }
+      return game;
+    });
+    this.librarySubject.next(updatedLibrary);
   }
 
   public downloadAllArt() {


### PR DESCRIPTION
## Summary

Fixes the issue where updating artwork for an individual game causes the window to jump to the bottom of the page, disorienting the user.

## Root Cause

When fetching artwork via "Fetch Artwork" on a game card, `downloadArtByGameId()` called `refreshGamesFiles()` which re-fetched the entire library from disk and emitted a completely new array via the `BehaviorSubject`. Combined with `@for (item of visibleGames$ | async; track item)` tracking by object reference, Angular destroyed and recreated every game card DOM element, resetting the scroll container to the bottom.

## Changes

1. **`library.service.ts`** — Replace the full `refreshGamesFiles()` call in `downloadArtByGameId()` with a new `updateArtForGame(gameId)` method that:
   - Re-reads only the ART folder
   - Patches the artwork into the existing library array for the specific game
   - Emits the updated array without changing unaffected game objects

2. **`library.component.html`** — Change `track item` → `track item.gameId` so Angular uses stable identity tracking and reuses existing DOM elements when the library updates.

3. **`gamecard.component.ts`** — Implement `OnChanges` so the cover art thumbnail updates reactively when the game input reference changes (since we now spread a new object for the updated game).

## Testing

- Scroll to a game in the middle/bottom of the library
- Click the ellipsis menu → "Fetch Artwork"
- Verify the scroll position is preserved and the artwork updates in-place

Closes #13