### PR TITLE
feat: App list support enhancement

### DIFF
--- a/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.html
+++ b/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.html
@@ -3,7 +3,7 @@
   <div class="flex items-center gap-2 border-b border-base-content/10 px-5 py-3">
     <i-lucide name="trash-2" size="18" class="text-error"></i-lucide>
     <h2 class="font-display text-sm font-semibold tracking-wide">
-      @if (deleting) { Deleting PS1 App Game… }
+      @if (deleting) { Deleting App… }
       @else { Delete complete }
     </h2>
     <button class="btn btn-ghost btn-xs btn-square ml-auto" (click)="close()" [disabled]="deleting">
@@ -13,8 +13,8 @@
 
   <div class="delete-body flex flex-col gap-4 px-5 py-4">
     <div class="rounded-md border border-base-content/10 bg-base-100/30 p-3 text-sm">
-      <span class="font-semibold">{{ game().title || game().gameId }}</span>
-      <span class="ml-2 text-xs text-base-content/50">{{ game().gameId }}</span>
+      <span class="font-semibold">{{ game().title || game().appFolder }}</span>
+      <span class="ml-2 text-xs text-base-content/50">APP</span>
     </div>
 
     <div #logArea class="log-area rounded-md border border-base-content/10 bg-base-100/30">
@@ -63,7 +63,7 @@
       </div>
       @if (!overallSuccess) {
       <p class="mt-1 text-xs text-base-content/60">
-        The game may still be partially removed. Check the Logs page for details.
+        Some files could not be removed. Check the Logs page for details.
       </p>
       }
     </div>

--- a/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.scss
+++ b/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.scss
@@ -70,11 +70,11 @@
 }
 
 .log-entry.is-success .entry-icon {
-  color: #4ade80;
+  color: oklch(80.036% 0.18204 151.736);
 }
 
 .log-entry.is-error .entry-icon {
-  color: #f87171;
+  color: oklch(71.061% 0.16614 22.191);
 }
 
 .entry-label {
@@ -85,11 +85,11 @@
 }
 
 .log-entry.is-success .entry-label {
-  color: #4ade80;
+  color: oklch(80.036% 0.18204 151.736);
 }
 
 .log-entry.is-error .entry-label {
-  color: #f87171;
+  color: oklch(71.061% 0.16614 22.191);
 }
 
 .log-secondary {

--- a/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.scss
+++ b/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.scss
@@ -1,0 +1,115 @@
+:host {
+  display: block;
+}
+
+.delete-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+}
+
+.delete-modal {
+  position: fixed;
+  z-index: 51;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(34rem, calc(100vw - 2rem));
+  max-height: calc(100vh - 4rem);
+  display: flex;
+  flex-direction: column;
+  border-radius: 1rem;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.delete-body {
+  overflow-y: auto;
+  overflow-wrap: break-word;
+}
+
+/* ── Log area ──────────────────────────────────────────────── */
+
+.log-area {
+  overflow-y: auto;
+  max-height: 20rem;
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.log-entry {
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.08);
+}
+
+.log-entry:last-child {
+  border-bottom: none;
+}
+
+.log-entry.is-success {
+  background: rgba(74, 222, 128, 0.04);
+}
+
+.log-entry.is-error {
+  background: rgba(248, 113, 113, 0.06);
+}
+
+.log-primary {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-bottom: 0.15rem;
+}
+
+.entry-icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.log-entry.is-success .entry-icon {
+  color: #4ade80;
+}
+
+.log-entry.is-error .entry-icon {
+  color: #f87171;
+}
+
+.entry-label {
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.log-entry.is-success .entry-label {
+  color: #4ade80;
+}
+
+.log-entry.is-error .entry-label {
+  color: #f87171;
+}
+
+.log-secondary {
+  padding-left: 1.65rem;
+}
+
+.entry-path {
+  overflow-wrap: break-word;
+  word-break: break-all;
+  opacity: 0.75;
+  font-size: 0.65rem;
+}
+
+.entry-path-missing {
+  opacity: 0.65;
+  font-size: 0.65rem;
+}
+
+.log-error-detail {
+  padding-left: 1.65rem;
+  padding-top: 0.1rem;
+  opacity: 0.7;
+}

--- a/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.ts
+++ b/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.ts
@@ -1,11 +1,15 @@
 import { Component } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import { Game } from '@shared/types/game.type';
-import {
-  BaseDeleteDialogComponent,
-  DeleteEntry,
-} from '../delete-dialog-base';
+import { BaseDeleteDialogComponent, DeleteEntry } from '../delete-dialog-base';
 
+/**
+ * Delete-progress dialog for regular ELF apps.
+ *
+ * Uses the modern `deleteAppWithProgress` IPC channel and listens for
+ * `delete-app-progress` events. Artwork deletion is optional and matched
+ * by the boot ELF filename.
+ */
 @Component({
   selector: 'app-app-delete-dialog',
   imports: [LucideAngularModule],
@@ -13,15 +17,23 @@ import {
   styleUrl: './app-delete-dialog.component.scss',
 })
 export class AppDeleteDialogComponent extends BaseDeleteDialogComponent {
+  /** Requires `appFolder` (relative APPS path) and `filename` (boot ELF). */
   protected validateGame(g: Game): boolean {
     return !!g.appFolder && !!g.filename;
   }
 
-  protected registerProgressHandler(handler: (entry: DeleteEntry) => void): () => void {
+  /** Registers a listener for `delete-app-progress` IPC events. */
+  protected registerProgressHandler(
+    handler: (entry: DeleteEntry) => void,
+  ): () => void {
     window.libraryAPI.onDeleteAppProgress(handler);
     return () => window.libraryAPI.removeAllDeleteAppProgressListeners();
   }
 
+  /**
+   * Calls `deleteAppWithProgress` which recursively removes all files in the
+   * app folder and optionally artwork files matching the boot ELF name.
+   */
   protected async runDeletion(
     g: Game,
     currentDir: string,

--- a/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.ts
+++ b/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.ts
@@ -1,24 +1,10 @@
-import {
-  ChangeDetectorRef,
-  Component,
-  DestroyRef,
-  ElementRef,
-  inject,
-  input,
-  output,
-  viewChild,
-} from '@angular/core';
+import { Component } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import { Game } from '@shared/types/game.type';
-import { LibraryService } from '@shared/services/library.service';
-
-interface DeleteEntry {
-  label: string;
-  path?: string;
-  success: boolean;
-  error?: string;
-  id?: number;
-}
+import {
+  BaseDeleteDialogComponent,
+  DeleteEntry,
+} from '../delete-dialog-base';
 
 @Component({
   selector: 'app-app-delete-dialog',
@@ -26,76 +12,25 @@ interface DeleteEntry {
   templateUrl: './app-delete-dialog.component.html',
   styleUrl: './app-delete-dialog.component.scss',
 })
-export class AppDeleteDialogComponent {
-  readonly game = input.required<Game>();
-  readonly deleteArtwork = input(false);
-  readonly closed = output<void>();
-  readonly logAreaRef = viewChild<ElementRef<HTMLElement>>('logArea');
-
-  entries: DeleteEntry[] = [];
-  deleting = true;
-  overallSuccess = true;
-  private entryIdCounter = 0;
-  private destroyed = false;
-  private readonly _cdr = inject(ChangeDetectorRef);
-  private readonly _destroyRef = inject(DestroyRef);
-
-  constructor(private readonly _libraryService: LibraryService) {
-    this._destroyRef.onDestroy(() => {
-      this.destroyed = true;
-      window.libraryAPI.removeAllDeleteAppProgressListeners();
-    });
+export class AppDeleteDialogComponent extends BaseDeleteDialogComponent {
+  protected validateGame(g: Game): boolean {
+    return !!g.appFolder && !!g.filename;
   }
 
-  async ngOnInit() {
-    const g = this.game();
-    if (!g || !g.appFolder || !g.filename) return;
-
-    const handleProgress = (entry: DeleteEntry) => {
-      if (this.destroyed) return;
-      this.entries = [...this.entries, { ...entry, id: ++this.entryIdCounter }];
-      if (!entry.success) this.overallSuccess = false;
-      this._cdr.detectChanges();
-      setTimeout(() => {
-        const el = this.logAreaRef()?.nativeElement;
-        if (el) {
-          el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
-        }
-      });
-    };
-    window.libraryAPI.onDeleteAppProgress(handleProgress);
-
-    try {
-      const currentDir = this._libraryService.currentDirectoryValue ?? '';
-      const result = await window.libraryAPI.deleteAppWithProgress(
-        currentDir,
-        g.appFolder,
-        this.deleteArtwork() ? g.filename : '',
-      );
-      if (result) {
-        this.overallSuccess = !!result.success;
-        for (const entry of (result.entries || [])) {
-          const exists = this.entries.some(
-            e => e.label === entry.label && e.path === entry.path
-          );
-          if (!exists) {
-            this.entries = [...this.entries, { ...entry, id: ++this.entryIdCounter }];
-          }
-        }
-      }
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      this.entries = [...this.entries, { label: 'Error', success: false, error: msg, id: ++this.entryIdCounter }];
-      this.overallSuccess = false;
-    } finally {
-      window.libraryAPI.removeAllDeleteAppProgressListeners();
-      this.deleting = false;
-      if (!this.destroyed) this._cdr.detectChanges();
-    }
+  protected registerProgressHandler(handler: (entry: DeleteEntry) => void): () => void {
+    window.libraryAPI.onDeleteAppProgress(handler);
+    return () => window.libraryAPI.removeAllDeleteAppProgressListeners();
   }
 
-  close() {
-    if (this.deleting) return;
-    this.closed.emit();
+  protected async runDeletion(
+    g: Game,
+    currentDir: string,
+    deleteArtwork: boolean,
+  ) {
+    return window.libraryAPI.deleteAppWithProgress(
+      currentDir,
+      g.appFolder!,
+      deleteArtwork ? g.filename : undefined,
+    );
   }
 }

--- a/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.ts
+++ b/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.ts
@@ -1,0 +1,100 @@
+import {
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  ElementRef,
+  inject,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
+import { LucideAngularModule } from 'lucide-angular';
+import { Game } from '@shared/types/game.type';
+import { LibraryService } from '@shared/services/library.service';
+
+interface DeleteEntry {
+  label: string;
+  path?: string;
+  success: boolean;
+  error?: string;
+  id?: number;
+}
+
+@Component({
+  selector: 'app-app-delete-dialog',
+  imports: [LucideAngularModule],
+  templateUrl: './app-delete-dialog.component.html',
+  styleUrl: './app-delete-dialog.component.scss',
+})
+export class AppDeleteDialogComponent {
+  readonly game = input.required<Game>();
+  readonly closed = output<void>();
+  readonly logAreaRef = viewChild<ElementRef<HTMLElement>>('logArea');
+
+  entries: DeleteEntry[] = [];
+  deleting = true;
+  overallSuccess = true;
+  private entryIdCounter = 0;
+  private destroyed = false;
+  private readonly _cdr = inject(ChangeDetectorRef);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  constructor(private readonly _libraryService: LibraryService) {
+    this._destroyRef.onDestroy(() => {
+      this.destroyed = true;
+      window.libraryAPI.removeAllDeleteAppProgressListeners();
+    });
+  }
+
+  async ngOnInit() {
+    const g = this.game();
+    if (!g || !g.appFolder || !g.filename) return;
+
+    const handleProgress = (entry: DeleteEntry) => {
+      if (this.destroyed) return;
+      this.entries = [...this.entries, { ...entry, id: ++this.entryIdCounter }];
+      if (!entry.success) this.overallSuccess = false;
+      this._cdr.detectChanges();
+      setTimeout(() => {
+        const el = this.logAreaRef()?.nativeElement;
+        if (el) {
+          el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
+        }
+      });
+    };
+    window.libraryAPI.onDeleteAppProgress(handleProgress);
+
+    try {
+      const currentDir = this._libraryService.currentDirectoryValue ?? '';
+      const result = await window.libraryAPI.deleteAppWithProgress(
+        currentDir,
+        g.appFolder,
+        g.filename,
+      );
+      if (result) {
+        this.overallSuccess = !!result.success;
+        for (const entry of (result.entries || [])) {
+          const exists = this.entries.some(
+            e => e.label === entry.label && e.path === entry.path
+          );
+          if (!exists) {
+            this.entries = [...this.entries, { ...entry, id: ++this.entryIdCounter }];
+          }
+        }
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.entries = [...this.entries, { label: 'Error', success: false, error: msg, id: ++this.entryIdCounter }];
+      this.overallSuccess = false;
+    } finally {
+      window.libraryAPI.removeAllDeleteAppProgressListeners();
+      this.deleting = false;
+      if (!this.destroyed) this._cdr.detectChanges();
+    }
+  }
+
+  close() {
+    if (this.deleting) return;
+    this.closed.emit();
+  }
+}

--- a/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.ts
+++ b/angular/src/app/pages/library/components/app-delete-dialog/app-delete-dialog.component.ts
@@ -28,6 +28,7 @@ interface DeleteEntry {
 })
 export class AppDeleteDialogComponent {
   readonly game = input.required<Game>();
+  readonly deleteArtwork = input(false);
   readonly closed = output<void>();
   readonly logAreaRef = viewChild<ElementRef<HTMLElement>>('logArea');
 
@@ -69,7 +70,7 @@ export class AppDeleteDialogComponent {
       const result = await window.libraryAPI.deleteAppWithProgress(
         currentDir,
         g.appFolder,
-        g.filename,
+        this.deleteArtwork() ? g.filename : '',
       );
       if (result) {
         this.overallSuccess = !!result.success;

--- a/angular/src/app/pages/library/components/delete-dialog-base.ts
+++ b/angular/src/app/pages/library/components/delete-dialog-base.ts
@@ -11,23 +11,49 @@ import {
 import { Game } from '@shared/types/game.type';
 import { LibraryService } from '@shared/services/library.service';
 
+/** A single entry in the deletion progress log. */
 export interface DeleteEntry {
+  /** Short human-readable label (e.g. "Game file", "ART file"). */
   label: string;
+  /** Full filesystem path of the deleted item, if applicable. */
   path?: string;
+  /** Whether this individual operation succeeded. */
   success: boolean;
+  /** Error message if the operation failed. */
   error?: string;
+  /** Monotonically increasing ID for `ngFor` tracking. */
   id?: number;
 }
 
+/**
+ * Abstract base for delete-progress dialogs.
+ *
+ * Handles the common lifecycle:
+ *   1. Validate the game object via {@link validateGame}.
+ *   2. Register a progress listener via {@link registerProgressHandler}.
+ *   3. Execute deletion via {@link runDeletion}.
+ *   4. Merge real-time progress entries with the final result set.
+ *   5. Clean up listeners and flip `deleting` to `false`.
+ *
+ * Subclasses only need to implement the three abstract methods for
+ * their specific IPC channels and backend API calls.
+ */
 @Directive()
 export abstract class BaseDeleteDialogComponent {
+  /** The game being deleted. */
   readonly game = input.required<Game>();
+  /** Whether to also delete associated artwork files. */
   readonly deleteArtwork = input(false);
+  /** Emitted when the user closes the dialog after deletion completes. */
   readonly closed = output<void>();
+  /** Reference to the scrollable log area for auto-scrolling. */
   readonly logAreaRef = viewChild<ElementRef<HTMLElement>>('logArea');
 
+  /** Progress entries accumulated during deletion. */
   entries: DeleteEntry[] = [];
+  /** Whether the deletion is still in progress. */
   deleting = true;
+  /** Whether every operation succeeded. */
   overallSuccess = true;
 
   protected entryIdCounter = 0;
@@ -45,10 +71,24 @@ export abstract class BaseDeleteDialogComponent {
     });
   }
 
+  /**
+   * Guard the game object before deletion begins.
+   * Return `false` to abort — the dialog will stay open with no entries.
+   */
   protected abstract validateGame(g: Game): boolean;
+
+  /**
+   * Subscribe to real-time progress events from the main process.
+   * Must return a cleanup function that removes the listener.
+   */
   protected abstract registerProgressHandler(
     handler: (entry: DeleteEntry) => void,
   ): () => void;
+
+  /**
+   * Execute the actual deletion and return the final result.
+   * `currentDir` is the OPL root directory (normalised to forward slashes).
+   */
   protected abstract runDeletion(
     g: Game,
     currentDir: string,
@@ -112,11 +152,13 @@ export abstract class BaseDeleteDialogComponent {
     }
   }
 
+  /** Close the dialog — only allowed after deletion is complete. */
   close() {
     if (this.deleting) return;
     this.closed.emit();
   }
 
+  /** Read and normalise the current OPL root directory. */
   private _getCurrentDir(): string {
     return (this._libraryService.currentDirectoryValue ?? '').replace(
       /[\\/]/g,

--- a/angular/src/app/pages/library/components/delete-dialog-base.ts
+++ b/angular/src/app/pages/library/components/delete-dialog-base.ts
@@ -1,0 +1,126 @@
+import {
+  ChangeDetectorRef,
+  DestroyRef,
+  Directive,
+  ElementRef,
+  inject,
+  input,
+  output,
+  viewChild,
+} from '@angular/core';
+import { Game } from '@shared/types/game.type';
+import { LibraryService } from '@shared/services/library.service';
+
+export interface DeleteEntry {
+  label: string;
+  path?: string;
+  success: boolean;
+  error?: string;
+  id?: number;
+}
+
+@Directive()
+export abstract class BaseDeleteDialogComponent {
+  readonly game = input.required<Game>();
+  readonly deleteArtwork = input(false);
+  readonly closed = output<void>();
+  readonly logAreaRef = viewChild<ElementRef<HTMLElement>>('logArea');
+
+  entries: DeleteEntry[] = [];
+  deleting = true;
+  overallSuccess = true;
+
+  protected entryIdCounter = 0;
+  private destroyed = false;
+  private _cleanupProgress?: () => void;
+
+  protected readonly _libraryService = inject(LibraryService);
+  private readonly _cdr = inject(ChangeDetectorRef);
+  private readonly _destroyRef = inject(DestroyRef);
+
+  constructor() {
+    this._destroyRef.onDestroy(() => {
+      this.destroyed = true;
+      this._cleanupProgress?.();
+    });
+  }
+
+  protected abstract validateGame(g: Game): boolean;
+  protected abstract registerProgressHandler(
+    handler: (entry: DeleteEntry) => void,
+  ): () => void;
+  protected abstract runDeletion(
+    g: Game,
+    currentDir: string,
+    deleteArtwork: boolean,
+  ): Promise<{ success: boolean; entries: DeleteEntry[] }>;
+
+  async ngOnInit() {
+    const g = this.game();
+    if (!g || !this.validateGame(g)) return;
+
+    this._cleanupProgress = this.registerProgressHandler((entry) => {
+      if (this.destroyed) return;
+      this.entries = [...this.entries, { ...entry, id: ++this.entryIdCounter }];
+      if (!entry.success) this.overallSuccess = false;
+      this._cdr.detectChanges();
+      setTimeout(() => {
+        const el = this.logAreaRef()?.nativeElement;
+        if (el) {
+          el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
+        }
+      });
+    });
+
+    try {
+      const currentDir = this._getCurrentDir();
+      const result = await this.runDeletion(
+        g,
+        currentDir,
+        this.deleteArtwork(),
+      );
+      if (result) {
+        this.overallSuccess = !!result.success;
+        for (const entry of result.entries || []) {
+          const exists = this.entries.some(
+            (e) => e.label === entry.label && e.path === entry.path,
+          );
+          if (!exists) {
+            this.entries = [
+              ...this.entries,
+              { ...entry, id: ++this.entryIdCounter },
+            ];
+          }
+        }
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.entries = [
+        ...this.entries,
+        {
+          label: 'Error',
+          success: false,
+          error: msg,
+          id: ++this.entryIdCounter,
+        },
+      ];
+      this.overallSuccess = false;
+    } finally {
+      if (this._cleanupProgress) this._cleanupProgress();
+      this.deleting = false;
+      if (!this.destroyed) this._cdr.detectChanges();
+    }
+  }
+
+  close() {
+    if (this.deleting) return;
+    this.closed.emit();
+  }
+
+  private _getCurrentDir(): string {
+    return (this._libraryService.currentDirectoryValue ?? '').replace(
+      /[\\/]/g,
+      '/',
+    );
+  }
+}

--- a/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.html
+++ b/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.html
@@ -32,10 +32,14 @@
         [value]="title"
         (input)="title = titleInput.value"
       />
-      <span class="label text-xs"
-        >Shown in OPL instead of the filename. Leave blank to keep the
-        default.</span
-      >
+      <p class="label-info text-xs">
+        @if (game().isPs1Launcher) {
+        This only modifies the title shown in OPL and OrbitOPL list. It
+        does not rename the VCD file.
+        } @else {
+        Shown in OPL instead of the filename. Leave blank to keep the default.
+        }
+      </p>
     </fieldset>
 
     <!-- Compatibility modes — not applicable to PS1 launcher apps -->
@@ -75,6 +79,7 @@
           <select
             #slot1Select
             class="select w-full"
+            [disabled]="game().isPs1Launcher"
             (change)="vmc0 = slot1Select.value"
           >
             <option value="">(none)</option>
@@ -88,6 +93,7 @@
           <select
             #slot2Select
             class="select w-full"
+            [disabled]="game().isPs1Launcher"
             (change)="vmc1 = slot2Select.value"
           >
             <option value="">(none)</option>
@@ -117,7 +123,7 @@
     <button class="btn btn-ghost btn-sm" (click)="close()" [disabled]="saving">
       Cancel
     </button>
-    <button class="btn btn-primary btn-sm" (click)="save()" [disabled]="saving">
+    <button class="btn btn-primary btn-sm" (click)="save()" [disabled]="saving || !hasChanges">
       @if (saving) {
       <span class="loading loading-spinner loading-xs"></span>
       } @else {

--- a/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.html
+++ b/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.html
@@ -7,7 +7,7 @@
         Game settings
       </h2>
       <p class="truncate font-mono text-[0.68rem] text-base-content/50">
-        {{ game.gameId }}
+        {{ game().gameId }}
       </p>
     </div>
     <button class="btn btn-ghost btn-xs btn-square ml-auto" (click)="close()">
@@ -25,11 +25,12 @@
     <fieldset class="fieldset">
       <legend class="fieldset-legend">Display title override</legend>
       <input
+        #titleInput
         type="text"
         class="input w-full"
-        [placeholder]="game.title || game.gameId"
+        [placeholder]="game().title || game().gameId"
         [value]="title"
-        (input)="title = $any($event.target).value"
+        (input)="title = titleInput.value"
       />
       <span class="label text-xs"
         >Shown in OPL instead of the filename. Leave blank to keep the
@@ -37,7 +38,8 @@
       >
     </fieldset>
 
-    <!-- Compatibility modes -->
+    <!-- Compatibility modes — not applicable to PS1 launcher apps -->
+    @if (!game().isPs1Launcher) {
     <div>
       <span class="text-sm font-semibold">Compatibility modes</span>
       <div class="mt-2 grid grid-cols-1 gap-1.5 sm:grid-cols-2">
@@ -50,7 +52,7 @@
             type="checkbox"
             class="checkbox checkbox-sm checkbox-primary mt-0.5"
             [checked]="compat[$index]"
-            (change)="compat[$index] = $any($event.target).checked"
+            (change)="onCompatChange($index, $event)"
           />
           <span class="leading-tight">
             <span class="text-sm">Mode {{ mode.bit + 1 }}: {{ mode.label }}</span>
@@ -60,42 +62,46 @@
         }
       </div>
     </div>
+    }
 
-    <!-- VMC slots -->
+    <!-- VMC slots — PS1 launcher apps use per-game SLOT0/SLOT1.VMC -->
     <div>
-      <span class="text-sm font-semibold">Memory cards (VMC)</span>
+      <span class="text-sm font-semibold">
+        Memory cards (VMC){{ game().isPs1Launcher ? ' — POPS' : '' }}
+      </span>
       <div class="mt-2 grid grid-cols-1 gap-3 sm:grid-cols-2">
         <fieldset class="fieldset">
           <legend class="fieldset-legend">Slot 1</legend>
           <select
+            #slot1Select
             class="select w-full"
-            [value]="vmc0"
-            (change)="vmc0 = $any($event.target).value"
+            (change)="vmc0 = slot1Select.value"
           >
             <option value="">(none)</option>
-            @for (name of cardNames; track name) {
-            <option [value]="name">{{ name }}</option>
+            @for (name of game().isPs1Launcher ? slot0Names : cardNames; track name) {
+            <option [value]="name" [selected]="vmc0 === name">{{ name }}</option>
             }
           </select>
         </fieldset>
         <fieldset class="fieldset">
           <legend class="fieldset-legend">Slot 2</legend>
           <select
+            #slot2Select
             class="select w-full"
-            [value]="vmc1"
-            (change)="vmc1 = $any($event.target).value"
+            (change)="vmc1 = slot2Select.value"
           >
             <option value="">(none)</option>
-            @for (name of cardNames; track name) {
-            <option [value]="name">{{ name }}</option>
+            @for (name of game().isPs1Launcher ? slot1Names : cardNames; track name) {
+            <option [value]="name" [selected]="vmc1 === name">{{ name }}</option>
             }
           </select>
         </fieldset>
       </div>
-      <span class="label text-xs"
-        >Create cards on the Memory Cards page. Assigning one here writes it to
-        this game's config.</span
-      >
+      <span class="label text-xs">
+        {{ game().isPs1Launcher
+          ? 'VMCs detected from POPS/. Slot 1 → SLOT0.VMC, Slot 2 → SLOT1.VMC.'
+          : 'Create cards on the Memory Cards page. Assigning one here writes it to this game\'s config.' }}
+      </span>
     </div>
 
     @if (otherKeyCount > 0) {

--- a/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.html
+++ b/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.html
@@ -28,10 +28,14 @@
         #titleInput
         type="text"
         class="input w-full"
-        [placeholder]="game().title || game().gameId"
+        [class.input-error]="game().isPs1Launcher && title.trim() === ''"
+        placeholder="Display title"
         [value]="title"
         (input)="title = titleInput.value"
       />
+      @if (game().isPs1Launcher && title.trim() === '') {
+      <p class="mt-1 text-xs text-error">The display title cannot be empty.</p>
+      }
       <p class="label-info text-xs">
         @if (game().isPs1Launcher) {
         This only modifies the title shown in OPL and OrbitOPL list. It

--- a/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.html
+++ b/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.html
@@ -15,7 +15,7 @@
     </button>
   </div>
 
-  @if (loading) {
+  @if (loading()) {
   <div class="flex items-center justify-center py-12">
     <span class="loading loading-spinner text-accent"></span>
   </div>

--- a/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.scss
+++ b/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.scss
@@ -6,7 +6,7 @@
   position: fixed;
   inset: 0;
   z-index: 50;
-  background: rgba(0, 0, 0, 0.55);
+  background: oklch(0% 0 0 / 0.55);
   backdrop-filter: blur(2px);
 }
 
@@ -21,7 +21,7 @@
   display: flex;
   flex-direction: column;
   border-radius: 1rem;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 20px 60px oklch(0% 0 0 / 0.5);
   overflow: hidden;
 }
 

--- a/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.scss
+++ b/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.scss
@@ -28,3 +28,14 @@
 .cfg-body {
   overflow-y: auto;
 }
+
+.label-info {
+  width: 100%;
+  overflow-wrap: break-word;
+  word-break: break-word;
+  white-space: normal;
+  line-height: 1.4;
+  margin-top: 0.25rem;
+  color: var(--color-base-content);
+  opacity: 0.6;
+}

--- a/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
+++ b/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, input, output } from '@angular/core';
+import { Component, input, output, signal } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import { Game } from '@shared/types/game.type';
 import {
@@ -36,7 +36,7 @@ export class GameCfgDialogComponent {
   cards: VmcInfo[] = [];
   slot0Cards: VmcInfo[] = [];
   slot1Cards: VmcInfo[] = [];
-  loading = true;
+  loading = signal(true);
   saving = false;
 
   private readonly knownKeys = [
@@ -52,38 +52,40 @@ export class GameCfgDialogComponent {
   }
 
   async ngOnInit() {
-    const g = this.game();
-    this.entries = await this._cfg.getGameCfg(g.gameId);
-    this.title = this.entries[CFG_KEY_NAME] ?? '';
-    this.initialTitle = this.title;
+    try {
+      const g = this.game();
+      this.entries = await this._cfg.getGameCfg(g.gameId);
+      this.title = this.entries[CFG_KEY_NAME] ?? '';
+      this.initialTitle = this.title;
 
-    if (g.isPs1Launcher) {
-      const vmcSub = g.ps1VmcSub ?? '';
-      if (vmcSub) {
-        const vmcs = await this._vmc.checkPops(vmcSub);
-        if (vmcs.slot0) {
-          this.slot0Cards = [{ name: vmcs.slot0, sizeBytes: 0, sizeMb: 0 }];
-          this.vmc0 = vmcs.slot0;
+      if (g.isPs1Launcher) {
+        const vmcSub = g.ps1VmcSub ?? '';
+        if (vmcSub) {
+          const vmcs = await this._vmc.checkPops(vmcSub);
+          if (vmcs.slot0) {
+            this.slot0Cards = [{ name: vmcs.slot0, sizeBytes: 0, sizeMb: 0 }];
+            this.vmc0 = vmcs.slot0;
+          }
+          if (vmcs.slot1) {
+            this.slot1Cards = [{ name: vmcs.slot1, sizeBytes: 0, sizeMb: 0 }];
+            this.vmc1 = vmcs.slot1;
+          }
         }
-        if (vmcs.slot1) {
-          this.slot1Cards = [{ name: vmcs.slot1, sizeBytes: 0, sizeMb: 0 }];
-          this.vmc1 = vmcs.slot1;
-        }
+      } else {
+        this.cards = await this._vmc.refresh();
+        this.vmc0 = this.entries[CFG_KEY_VMC0] ?? '';
+        this.vmc1 = this.entries[CFG_KEY_VMC1] ?? '';
       }
-    } else {
-      this.cards = await this._vmc.refresh();
-      this.vmc0 = this.entries[CFG_KEY_VMC0] ?? '';
-      this.vmc1 = this.entries[CFG_KEY_VMC1] ?? '';
-    }
 
-    if (!g.isPs1Launcher) {
-      const compatVal = parseInt(this.entries[CFG_KEY_COMPAT] ?? '0', 10) || 0;
-      this.compat = this.compatModes.map(
-        (m) => (compatVal & (1 << m.bit)) !== 0,
-      );
+      if (!g.isPs1Launcher) {
+        const compatVal = parseInt(this.entries[CFG_KEY_COMPAT] ?? '0', 10) || 0;
+        this.compat = this.compatModes.map(
+          (m) => (compatVal & (1 << m.bit)) !== 0,
+        );
+      }
+    } finally {
+      this.loading.set(false);
     }
-
-    this.loading = false;
   }
 
   get cardNames(): string[] {

--- a/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
+++ b/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
@@ -122,33 +122,34 @@ export class GameCfgDialogComponent {
     if (trimmed) next[CFG_KEY_NAME] = trimmed;
     else delete next[CFG_KEY_NAME];
 
-    if (!this.game().isPs1Launcher) {
-      let mask = 0;
-      this.compatModes.forEach((m, i) => {
-        if (this.compat[i]) mask |= 1 << m.bit;
-      });
-      if (mask > 0) next[CFG_KEY_COMPAT] = String(mask);
-      else delete next[CFG_KEY_COMPAT];
-    } else {
+    const g = this.game();
+    if (g.isPs1Launcher) {
       delete next[CFG_KEY_COMPAT];
-    }
-
-    if (!this.game().isPs1Launcher) {
-      if (this.vmc0) next[CFG_KEY_VMC0] = this.vmc0;
-      else delete next[CFG_KEY_VMC0];
-      if (this.vmc1) next[CFG_KEY_VMC1] = this.vmc1;
-      else delete next[CFG_KEY_VMC1];
-    } else {
       delete next[CFG_KEY_VMC0];
       delete next[CFG_KEY_VMC1];
+      await this._cfg.saveGameCfg(g.gameId, next);
+      if (g.ps1LauncherPath) {
+        await window.libraryAPI.updatePs1TitleCfg(g.ps1LauncherPath, trimmed || g.gameId, g.gameId);
+      }
+      this.saving = false;
+      this.closed.emit();
+      return;
     }
 
-    await this._cfg.saveGameCfg(this.game().gameId, next);
+    // PS2 only below
+    let mask = 0;
+    this.compatModes.forEach((m, i) => {
+      if (this.compat[i]) mask |= 1 << m.bit;
+    });
+    if (mask > 0) next[CFG_KEY_COMPAT] = String(mask);
+    else delete next[CFG_KEY_COMPAT];
 
-    if (this.game().isPs1Launcher && this.game().ps1LauncherPath) {
-      const titleCfgTitle = trimmed || this.game().gameId;
-      await window.libraryAPI.updatePs1TitleCfg(this.game().ps1LauncherPath!, titleCfgTitle);
-    }
+    if (this.vmc0) next[CFG_KEY_VMC0] = this.vmc0;
+    else delete next[CFG_KEY_VMC0];
+    if (this.vmc1) next[CFG_KEY_VMC1] = this.vmc1;
+    else delete next[CFG_KEY_VMC1];
+
+    await this._cfg.saveGameCfg(g.gameId, next);
 
     this.saving = false;
     this.closed.emit();

--- a/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
+++ b/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
@@ -55,7 +55,7 @@ export class GameCfgDialogComponent {
     try {
       const g = this.game();
       this.entries = await this._cfg.getGameCfg(g.gameId);
-      this.title = this.entries[CFG_KEY_NAME] ?? '';
+      this.title = this.entries[CFG_KEY_NAME] ?? g.title ?? '';
       this.initialTitle = this.title;
 
       if (g.isPs1Launcher) {
@@ -110,7 +110,8 @@ export class GameCfgDialogComponent {
 
   get hasChanges(): boolean {
     if (this.game().isPs1Launcher) {
-      return this.title.trim() !== this.initialTitle;
+      const trimmed = this.title.trim();
+      return trimmed !== '' && trimmed !== this.initialTitle;
     }
     return true;
   }

--- a/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
+++ b/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
@@ -29,6 +29,7 @@ export class GameCfgDialogComponent {
 
   entries: GameCfg = {};
   title = '';
+  private initialTitle = '';
   compat: boolean[] = new Array(8).fill(false);
   vmc0 = '';
   vmc1 = '';
@@ -54,6 +55,7 @@ export class GameCfgDialogComponent {
     const g = this.game();
     this.entries = await this._cfg.getGameCfg(g.gameId);
     this.title = this.entries[CFG_KEY_NAME] ?? '';
+    this.initialTitle = this.title;
 
     if (g.isPs1Launcher) {
       const vmcSub = g.ps1VmcSub ?? '';
@@ -105,6 +107,13 @@ export class GameCfgDialogComponent {
     ).length;
   }
 
+  get hasChanges(): boolean {
+    if (this.game().isPs1Launcher) {
+      return this.title.trim() !== this.initialTitle;
+    }
+    return true;
+  }
+
   async save() {
     this.saving = true;
     const next: GameCfg = { ...this.entries };
@@ -135,6 +144,12 @@ export class GameCfgDialogComponent {
     }
 
     await this._cfg.saveGameCfg(this.game().gameId, next);
+
+    if (this.game().isPs1Launcher && this.game().ps1LauncherPath) {
+      const titleCfgTitle = trimmed || this.game().gameId;
+      await window.libraryAPI.updatePs1TitleCfg(this.game().ps1LauncherPath!, titleCfgTitle);
+    }
+
     this.saving = false;
     this.closed.emit();
   }

--- a/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
+++ b/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
@@ -30,7 +30,7 @@ export class GameCfgDialogComponent {
   entries: GameCfg = {};
   title = '';
   private initialTitle = '';
-  compat: boolean[] = new Array(8).fill(false);
+  compat: boolean[] = new Array(COMPAT_MODES.length).fill(false);
   vmc0 = '';
   vmc1 = '';
   cards: VmcInfo[] = [];

--- a/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
+++ b/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
@@ -1,10 +1,4 @@
-import {
-  Component,
-  EventEmitter,
-  Input,
-  OnInit,
-  Output,
-} from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import { Game } from '../../../../shared/types/game.type';
 import {
@@ -24,9 +18,12 @@ import { VmcInfo, VmcService } from '../../../../shared/services/vmc.service';
   templateUrl: './game-cfg-dialog.component.html',
   styleUrl: './game-cfg-dialog.component.scss',
 })
-export class GameCfgDialogComponent implements OnInit {
-  @Input({ required: true }) game!: Game;
-  @Output() closed = new EventEmitter<void>();
+export class GameCfgDialogComponent {
+  readonly game = input.required<Game>();
+  readonly closed = output<void>();
+
+  private readonly _cfg: CfgService;
+  private readonly _vmc: VmcService;
 
   readonly compatModes = COMPAT_MODES;
 
@@ -36,24 +33,10 @@ export class GameCfgDialogComponent implements OnInit {
   vmc0 = '';
   vmc1 = '';
   cards: VmcInfo[] = [];
+  slot0Cards: VmcInfo[] = [];
+  slot1Cards: VmcInfo[] = [];
   loading = true;
   saving = false;
-
-  constructor(
-    private readonly _cfg: CfgService,
-    private readonly _vmc: VmcService
-  ) {}
-
-  async ngOnInit() {
-    this.cards = await this._vmc.refresh();
-    this.entries = await this._cfg.getGameCfg(this.game.gameId);
-    this.title = this.entries[CFG_KEY_NAME] ?? '';
-    const compatVal = parseInt(this.entries[CFG_KEY_COMPAT] ?? '0', 10) || 0;
-    this.compat = this.compatModes.map((m) => (compatVal & (1 << m.bit)) !== 0);
-    this.vmc0 = this.entries[CFG_KEY_VMC0] ?? '';
-    this.vmc1 = this.entries[CFG_KEY_VMC1] ?? '';
-    this.loading = false;
-  }
 
   private readonly knownKeys = [
     CFG_KEY_NAME,
@@ -62,7 +45,45 @@ export class GameCfgDialogComponent implements OnInit {
     CFG_KEY_VMC1,
   ];
 
-  /** Card names to offer, including any assigned card no longer on disk. */
+  constructor(cfg: CfgService, vmc: VmcService) {
+    this._cfg = cfg;
+    this._vmc = vmc;
+  }
+
+  async ngOnInit() {
+    const g = this.game();
+    this.entries = await this._cfg.getGameCfg(g.gameId);
+    this.title = this.entries[CFG_KEY_NAME] ?? '';
+
+    if (g.isPs1Launcher) {
+      const vmcSub = g.ps1VmcSub ?? '';
+      if (vmcSub) {
+        const vmcs = await this._vmc.checkPops(vmcSub);
+        if (vmcs.slot0) {
+          this.slot0Cards = [{ name: vmcs.slot0, sizeBytes: 0, sizeMb: 0 }];
+          this.vmc0 = vmcs.slot0;
+        }
+        if (vmcs.slot1) {
+          this.slot1Cards = [{ name: vmcs.slot1, sizeBytes: 0, sizeMb: 0 }];
+          this.vmc1 = vmcs.slot1;
+        }
+      }
+    } else {
+      this.cards = await this._vmc.refresh();
+      this.vmc0 = this.entries[CFG_KEY_VMC0] ?? '';
+      this.vmc1 = this.entries[CFG_KEY_VMC1] ?? '';
+    }
+
+    if (!g.isPs1Launcher) {
+      const compatVal = parseInt(this.entries[CFG_KEY_COMPAT] ?? '0', 10) || 0;
+      this.compat = this.compatModes.map(
+        (m) => (compatVal & (1 << m.bit)) !== 0,
+      );
+    }
+
+    this.loading = false;
+  }
+
   get cardNames(): string[] {
     const names = new Set(this.cards.map((c) => c.name));
     if (this.vmc0) names.add(this.vmc0);
@@ -70,9 +91,17 @@ export class GameCfgDialogComponent implements OnInit {
     return Array.from(names).sort((a, b) => a.localeCompare(b));
   }
 
+  get slot0Names(): string[] {
+    return this.slot0Cards.map((c) => c.name);
+  }
+
+  get slot1Names(): string[] {
+    return this.slot1Cards.map((c) => c.name);
+  }
+
   get otherKeyCount(): number {
     return Object.keys(this.entries).filter(
-      (k) => !this.knownKeys.includes(k)
+      (k) => !this.knownKeys.includes(k),
     ).length;
   }
 
@@ -84,21 +113,35 @@ export class GameCfgDialogComponent implements OnInit {
     if (trimmed) next[CFG_KEY_NAME] = trimmed;
     else delete next[CFG_KEY_NAME];
 
-    let mask = 0;
-    this.compatModes.forEach((m, i) => {
-      if (this.compat[i]) mask |= 1 << m.bit;
-    });
-    if (mask > 0) next[CFG_KEY_COMPAT] = String(mask);
-    else delete next[CFG_KEY_COMPAT];
+    if (!this.game().isPs1Launcher) {
+      let mask = 0;
+      this.compatModes.forEach((m, i) => {
+        if (this.compat[i]) mask |= 1 << m.bit;
+      });
+      if (mask > 0) next[CFG_KEY_COMPAT] = String(mask);
+      else delete next[CFG_KEY_COMPAT];
+    } else {
+      delete next[CFG_KEY_COMPAT];
+    }
 
-    if (this.vmc0) next[CFG_KEY_VMC0] = this.vmc0;
-    else delete next[CFG_KEY_VMC0];
-    if (this.vmc1) next[CFG_KEY_VMC1] = this.vmc1;
-    else delete next[CFG_KEY_VMC1];
+    if (!this.game().isPs1Launcher) {
+      if (this.vmc0) next[CFG_KEY_VMC0] = this.vmc0;
+      else delete next[CFG_KEY_VMC0];
+      if (this.vmc1) next[CFG_KEY_VMC1] = this.vmc1;
+      else delete next[CFG_KEY_VMC1];
+    } else {
+      delete next[CFG_KEY_VMC0];
+      delete next[CFG_KEY_VMC1];
+    }
 
-    await this._cfg.saveGameCfg(this.game.gameId, next);
+    await this._cfg.saveGameCfg(this.game().gameId, next);
     this.saving = false;
     this.closed.emit();
+  }
+
+  onCompatChange(index: number, event: Event): void {
+    const input = event.target as HTMLInputElement | null;
+    if (input) this.compat[index] = input.checked;
   }
 
   close() {

--- a/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
+++ b/angular/src/app/pages/library/components/game-cfg-dialog/game-cfg-dialog.component.ts
@@ -1,6 +1,6 @@
 import { Component, input, output } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
-import { Game } from '../../../../shared/types/game.type';
+import { Game } from '@shared/types/game.type';
 import {
   CfgService,
   COMPAT_MODES,
@@ -9,8 +9,8 @@ import {
   CFG_KEY_VMC0,
   CFG_KEY_VMC1,
   GameCfg,
-} from '../../../../shared/services/cfg.service';
-import { VmcInfo, VmcService } from '../../../../shared/services/vmc.service';
+} from '@shared/services/cfg.service';
+import { VmcInfo, VmcService } from '@shared/services/vmc.service';
 
 @Component({
   selector: 'app-game-cfg-dialog',
@@ -102,9 +102,8 @@ export class GameCfgDialogComponent {
   }
 
   get otherKeyCount(): number {
-    return Object.keys(this.entries).filter(
-      (k) => !this.knownKeys.includes(k),
-    ).length;
+    return Object.keys(this.entries).filter((k) => !this.knownKeys.includes(k))
+      .length;
   }
 
   get hasChanges(): boolean {
@@ -129,7 +128,11 @@ export class GameCfgDialogComponent {
       delete next[CFG_KEY_VMC1];
       await this._cfg.saveGameCfg(g.gameId, next);
       if (g.ps1LauncherPath) {
-        await window.libraryAPI.updatePs1TitleCfg(g.ps1LauncherPath, trimmed || g.gameId, g.gameId);
+        await window.libraryAPI.updatePs1TitleCfg(
+          g.ps1LauncherPath,
+          trimmed || g.gameId,
+          g.gameId,
+        );
       }
       this.saving = false;
       this.closed.emit();

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.html
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.html
@@ -14,7 +14,9 @@
     {{ game()?.title || game()?.gameId }}
   </div>
   <span class="row-meta font-mono">{{ game()?.gameId }}</span>
+  @if(!isApp()) {
   <span class="chip chip-region font-mono">{{ game()?.region }}</span>
+  }
   <span class="row-meta font-mono">{{ game()?.size }}</span>
   <span class="chip font-mono">{{ game()?.format || game()?.extension }}</span>
   <div class="dropdown dropdown-end row-actions">
@@ -50,7 +52,7 @@
 } @else {
 <!-- ── Grid poster ───────────────────────────────────────────── -->
 <div class="tile poster">
-  <div class="poster-art" [class.is-square]="game()?.isPs1Launcher">
+  <div class="poster-art" [class.is-square]="game()?.system === 'APPS'">
     <div class="poster-art-clip">
       @if(displayArt()) {
       <img [src]="artSrc()" alt="cover art" />
@@ -63,7 +65,7 @@
     </div>
 
     <!-- top overlays -->
-    <span class="poster-system" [class.is-ps1]="game()?.system === 'PS1'" [class.is-ps1-app]="game()?.isPs1Launcher">{{
+    <span class="poster-system" [class.is-ps1]="game()?.system === 'PS1'" [class.is-ps1-app]="game()?.system === 'APPS'">{{
       displaySystemLabel()
       }}</span>
 
@@ -103,7 +105,9 @@
         {{ game()?.title || game()?.gameId }}
       </div>
       <div class="poster-meta">
+        @if(!isApp()) {
         <span class="chip chip-region font-mono">{{ game()?.region }}</span>
+        }
         <span class="chip font-mono">{{ game()?.format || game()?.extension }}</span>
         <span class="poster-size font-mono">{{ game()?.size }}</span>
       </div>
@@ -125,4 +129,9 @@
 @if(showDeleteDialog && game()) {
 <app-ps1-delete-dialog [game]="game()!"
   (closed)="showDeleteDialog = false; _libraryService.refreshGamesFiles()"></app-ps1-delete-dialog>
+}
+
+@if(showAppDeleteDialog && game()) {
+<app-app-delete-dialog [game]="game()!"
+  (closed)="showAppDeleteDialog = false; _libraryService.refreshGamesFiles()"></app-app-delete-dialog>
 }

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.html
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.html
@@ -2,9 +2,9 @@
 <!-- ── List row ──────────────────────────────────────────────── -->
 <div class="game-row row-item">
   <figure class="row-art">
-    @if(displayArt()) {
-    <img [src]="'data:image/png;base64,' + displayArt()!.base64" alt="" />
-    } @else {
+      @if(displayArt()) {
+      <img [src]="artSrc()" alt="" />
+      } @else {
     <div class="row-no-art">
       <i-lucide name="image-off" size="18"></i-lucide>
     </div>
@@ -53,7 +53,7 @@
   <div class="poster-art" [class.is-square]="game()?.isPs1Launcher">
     <div class="poster-art-clip">
       @if(displayArt()) {
-      <img [src]="'data:image/png;base64,' + displayArt()!.base64" alt="cover art" />
+      <img [src]="artSrc()" alt="cover art" />
       } @else {
       <div class="poster-no-art">
         <i-lucide name="image-off" size="40"></i-lucide>
@@ -64,7 +64,7 @@
 
     <!-- top overlays -->
     <span class="poster-system" [class.is-ps1]="game()?.system === 'PS1'" [class.is-ps1-app]="game()?.isPs1Launcher">{{
-      game()?.isPs1Launcher ? "PS1 App" : game()?.system === "PS1" ? "PS1" : game()?.system === "APPS" ? "APP" : "PS2"
+      displaySystemLabel()
       }}</span>
 
     <div class="dropdown dropdown-end poster-menu">

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.html
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.html
@@ -124,5 +124,5 @@
 
 @if(showDeleteDialog && game()) {
 <app-ps1-delete-dialog [game]="game()!"
-  (closed)="showDeleteDialog = false"></app-ps1-delete-dialog>
+  (closed)="showDeleteDialog = false; _libraryService.refreshGamesFiles()"></app-ps1-delete-dialog>
 }

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.html
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.html
@@ -1,22 +1,22 @@
-@if(viewMode === 'list') {
+@if(viewMode() === 'list') {
 <!-- ── List row ──────────────────────────────────────────────── -->
 <div class="game-row row-item">
   <figure class="row-art">
-    @if(displayArt) {
-    <img [src]="'data:image/png;base64,' + displayArt.base64" alt="" />
+    @if(displayArt()) {
+    <img [src]="'data:image/png;base64,' + displayArt()!.base64" alt="" />
     } @else {
     <div class="row-no-art">
       <i-lucide name="image-off" size="18"></i-lucide>
     </div>
     }
   </figure>
-  <div class="row-title" [title]="game?.title || game?.gameId || ''">
-    {{ game?.title || game?.gameId }}
+  <div class="row-title" [title]="game()?.title || game()?.gameId || ''">
+    {{ game()?.title || game()?.gameId }}
   </div>
-  <span class="row-meta font-mono">{{ game?.gameId }}</span>
-  <span class="chip chip-region font-mono">{{ game?.region }}</span>
-  <span class="row-meta font-mono">{{ game?.size }}</span>
-  <span class="chip font-mono">{{ game?.format || game?.extension }}</span>
+  <span class="row-meta font-mono">{{ game()?.gameId }}</span>
+  <span class="chip chip-region font-mono">{{ game()?.region }}</span>
+  <span class="row-meta font-mono">{{ game()?.size }}</span>
+  <span class="chip font-mono">{{ game()?.format || game()?.extension }}</span>
   <div class="dropdown dropdown-end row-actions">
     <div tabindex="0" role="button" class="btn btn-sm btn-ghost btn-square">
       <i-lucide name="ellipsis-vertical" size="16"></i-lucide>
@@ -25,7 +25,7 @@
       tabindex="-1"
       class="dropdown-content menu glass-strong rounded-box z-10 w-48 p-2 shadow-xl"
     >
-      @if(!isApp) {
+      @if(!isApp() || isPs1LauncherApp()) {
       <li>
         <a (click)="fetchArtwork()"
           ><i-lucide name="image-down" [size]="16"></i-lucide>Fetch artwork</a
@@ -37,14 +37,14 @@
         >
       </li>
       }
-      @if(canCompressZso) {
+      @if(canCompressZso()) {
       <li>
         <a (click)="convertToZso()"
           ><i-lucide name="file-archive" [size]="16"></i-lucide>Convert to ZSO</a
         >
       </li>
       }
-      @if(canRenameConvention) {
+      @if(canRenameConvention()) {
       <li>
         <a (click)="openRename()"
           ><i-lucide name="text-cursor-input" [size]="16"></i-lucide>Rename to convention…</a
@@ -62,17 +62,14 @@
 } @else {
 <!-- ── Grid poster ───────────────────────────────────────────── -->
 <div class="tile poster">
-  <div class="poster-art">
-    <!-- Image goes in its own clipped wrapper so the dropdown menu can extend
-         past the tile bounds without getting cut off (overflow:hidden lives
-         on .poster-art-clip, not on .poster-art). -->
+  <div class="poster-art" [class.is-square]="game()?.isPs1Launcher">
     <div class="poster-art-clip">
-      @if(displayArt) {
-      <img [src]="'data:image/png;base64,' + displayArt.base64" alt="cover art" />
+      @if(displayArt()) {
+      <img [src]="'data:image/png;base64,' + displayArt()!.base64" alt="cover art" />
       } @else {
       <div class="poster-no-art">
         <i-lucide name="image-off" size="40"></i-lucide>
-        <span class="font-mono text-xs">{{ game?.gameId || game?.title }}</span>
+        <span class="font-mono text-xs">{{ game()?.gameId || game()?.title }}</span>
       </div>
       }
     </div>
@@ -80,8 +77,9 @@
     <!-- top overlays -->
     <span
       class="poster-system"
-      [class.is-ps1]="game?.system === 'PS1'"
-      >{{ game?.system === "PS1" ? "PS1" : game?.system === "APPS" ? "APP" : "PS2" }}</span
+      [class.is-ps1]="game()?.system === 'PS1'"
+      [class.is-ps1-app]="game()?.isPs1Launcher"
+      >{{ game()?.isPs1Launcher ? "PS1 App" : game()?.system === "PS1" ? "PS1" : game()?.system === "APPS" ? "APP" : "PS2" }}</span
     >
 
     <div class="dropdown dropdown-end poster-menu">
@@ -92,6 +90,7 @@
         tabindex="-1"
         class="dropdown-content menu glass-strong rounded-box z-10 w-48 p-2 shadow-xl"
       >
+        @if(!isApp() || isPs1LauncherApp()) {
         <li>
           <a (click)="fetchArtwork()"
             ><i-lucide name="image-down" [size]="16"></i-lucide>Fetch artwork</a
@@ -102,14 +101,15 @@
             ><i-lucide name="sliders-horizontal" [size]="16"></i-lucide>Game settings</a
           >
         </li>
-        @if(canCompressZso) {
+        }
+        @if(canCompressZso()) {
         <li>
           <a (click)="convertToZso()"
             ><i-lucide name="file-archive" [size]="16"></i-lucide>Convert to ZSO</a
           >
         </li>
         }
-        @if(canRenameConvention) {
+        @if(canRenameConvention()) {
         <li>
           <a (click)="openRename()"
             ><i-lucide name="text-cursor-input" [size]="16"></i-lucide>Rename to convention…</a
@@ -126,26 +126,26 @@
 
     <!-- bottom gradient + title -->
     <div class="poster-overlay">
-      <div class="poster-title" [title]="game?.title || game?.gameId || ''">
-        {{ game?.title || game?.gameId }}
+      <div class="poster-title" [title]="game()?.title || game()?.gameId || ''">
+        {{ game()?.title || game()?.gameId }}
       </div>
       <div class="poster-meta">
-        <span class="chip chip-region font-mono">{{ game?.region }}</span>
-        <span class="chip font-mono">{{ game?.format || game?.extension }}</span>
-        <span class="poster-size font-mono">{{ game?.size }}</span>
+        <span class="chip chip-region font-mono">{{ game()?.region }}</span>
+        <span class="chip font-mono">{{ game()?.format || game()?.extension }}</span>
+        <span class="poster-size font-mono">{{ game()?.size }}</span>
       </div>
     </div>
   </div>
 </div>
 }
 
-@if(showCfg && game) {
-<app-game-cfg-dialog [game]="game" (closed)="showCfg = false"></app-game-cfg-dialog>
+@if(showCfg && game()) {
+<app-game-cfg-dialog [game]="game()!" (closed)="showCfg = false"></app-game-cfg-dialog>
 }
 
-@if(showRename && game) {
+@if(showRename && game()) {
 <app-library-rename-dialog
-  [game]="game"
+  [game]="game()!"
   (closed)="showRename = false"
 ></app-library-rename-dialog>
 }

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.html
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.html
@@ -127,11 +127,11 @@
 }
 
 @if(showDeleteDialog && game()) {
-<app-ps1-delete-dialog [game]="game()!"
+<app-ps1-delete-dialog [game]="game()!" [deleteArtwork]="deleteArtwork"
   (closed)="showDeleteDialog = false; _libraryService.refreshGamesFiles()"></app-ps1-delete-dialog>
 }
 
 @if(showAppDeleteDialog && game()) {
-<app-app-delete-dialog [game]="game()!"
+<app-app-delete-dialog [game]="game()!" [deleteArtwork]="deleteArtwork"
   (closed)="showAppDeleteDialog = false; _libraryService.refreshGamesFiles()"></app-app-delete-dialog>
 }

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.html
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.html
@@ -121,3 +121,8 @@
 <app-library-rename-dialog [game]="game()!"
   (closed)="showRename = false; _libraryService.refreshGamesFiles()"></app-library-rename-dialog>
 }
+
+@if(showDeleteDialog && game()) {
+<app-ps1-delete-dialog [game]="game()!"
+  (closed)="showDeleteDialog = false"></app-ps1-delete-dialog>
+}

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.html
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.html
@@ -18,7 +18,7 @@
   <span class="chip chip-region font-mono">{{ game()?.region }}</span>
   }
   <span class="row-meta font-mono">{{ game()?.size }}</span>
-  <span class="chip font-mono">{{ game()?.format || game()?.extension }}</span>
+  <span class="chip font-mono">{{ game()?.system === 'APPS' && !game()?.isPs1Launcher ? 'ELF' : (game()?.format || game()?.extension) }}</span>
   <div class="dropdown dropdown-end row-actions">
     <div tabindex="0" role="button" class="btn btn-sm btn-ghost btn-square">
       <i-lucide name="ellipsis-vertical" size="16"></i-lucide>
@@ -108,7 +108,7 @@
         @if(!isApp()) {
         <span class="chip chip-region font-mono">{{ game()?.region }}</span>
         }
-        <span class="chip font-mono">{{ game()?.format || game()?.extension }}</span>
+        <span class="chip font-mono">{{ game()?.system === 'APPS' && !game()?.isPs1Launcher ? 'ELF' : (game()?.format || game()?.extension) }}</span>
         <span class="poster-size font-mono">{{ game()?.size }}</span>
       </div>
     </div>

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.html
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.html
@@ -14,9 +14,7 @@
     {{ game()?.title || game()?.gameId }}
   </div>
   <span class="row-meta font-mono">{{ game()?.gameId }}</span>
-  @if(!isApp()) {
-  <span class="chip chip-region font-mono">{{ game()?.region }}</span>
-  }
+  <span class="chip chip-region font-mono" [style.visibility]="isApp() ? 'hidden' : 'visible'">{{ game()?.region }}</span>
   <span class="row-meta font-mono">{{ game()?.size }}</span>
   <span class="chip font-mono">{{ formatLabel() }}</span>
   <div class="dropdown dropdown-end row-actions">

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.html
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.html
@@ -21,40 +21,28 @@
     <div tabindex="0" role="button" class="btn btn-sm btn-ghost btn-square">
       <i-lucide name="ellipsis-vertical" size="16"></i-lucide>
     </div>
-    <ul
-      tabindex="-1"
-      class="dropdown-content menu glass-strong rounded-box z-10 w-48 p-2 shadow-xl"
-    >
+    <ul tabindex="-1" class="dropdown-content menu glass-strong rounded-box z-10 w-48 p-2 shadow-xl">
       @if(!isApp() || isPs1LauncherApp()) {
       <li>
-        <a (click)="fetchArtwork()"
-          ><i-lucide name="image-down" [size]="16"></i-lucide>Fetch artwork</a
-        >
+        <a (click)="fetchArtwork()"><i-lucide name="image-down" [size]="16"></i-lucide>Fetch artwork</a>
       </li>
       <li>
-        <a (click)="openCfg()"
-          ><i-lucide name="sliders-horizontal" [size]="16"></i-lucide>Game settings</a
-        >
+        <a (click)="openCfg()"><i-lucide name="sliders-horizontal" [size]="16"></i-lucide>Game settings</a>
       </li>
       }
       @if(canCompressZso()) {
       <li>
-        <a (click)="convertToZso()"
-          ><i-lucide name="file-archive" [size]="16"></i-lucide>Convert to ZSO</a
-        >
+        <a (click)="convertToZso()"><i-lucide name="file-archive" [size]="16"></i-lucide>Convert to ZSO</a>
       </li>
       }
       @if(canRenameConvention()) {
       <li>
-        <a (click)="openRename()"
-          ><i-lucide name="text-cursor-input" [size]="16"></i-lucide>Rename to convention…</a
-        >
+        <a (click)="openRename()"><i-lucide name="text-cursor-input" [size]="16"></i-lucide>{{ game()?.isPs1Launcher ?
+          'Rename game…' : 'Rename to convention…' }}</a>
       </li>
       }
       <li>
-        <a class="text-error" (click)="confirmDelete()"
-          ><i-lucide name="trash-2" [size]="16"></i-lucide>Delete</a
-        >
+        <a class="text-error" (click)="confirmDelete()"><i-lucide name="trash-2" [size]="16"></i-lucide>Delete</a>
       </li>
     </ul>
   </div>
@@ -75,51 +63,36 @@
     </div>
 
     <!-- top overlays -->
-    <span
-      class="poster-system"
-      [class.is-ps1]="game()?.system === 'PS1'"
-      [class.is-ps1-app]="game()?.isPs1Launcher"
-      >{{ game()?.isPs1Launcher ? "PS1 App" : game()?.system === "PS1" ? "PS1" : game()?.system === "APPS" ? "APP" : "PS2" }}</span
-    >
+    <span class="poster-system" [class.is-ps1]="game()?.system === 'PS1'" [class.is-ps1-app]="game()?.isPs1Launcher">{{
+      game()?.isPs1Launcher ? "PS1 App" : game()?.system === "PS1" ? "PS1" : game()?.system === "APPS" ? "APP" : "PS2"
+      }}</span>
 
     <div class="dropdown dropdown-end poster-menu">
       <div tabindex="0" role="button" class="btn btn-xs btn-square glass-strong">
         <i-lucide name="ellipsis" size="15"></i-lucide>
       </div>
-      <ul
-        tabindex="-1"
-        class="dropdown-content menu glass-strong rounded-box z-10 w-48 p-2 shadow-xl"
-      >
+      <ul tabindex="-1" class="dropdown-content menu glass-strong rounded-box z-10 w-48 p-2 shadow-xl">
         @if(!isApp() || isPs1LauncherApp()) {
         <li>
-          <a (click)="fetchArtwork()"
-            ><i-lucide name="image-down" [size]="16"></i-lucide>Fetch artwork</a
-          >
+          <a (click)="fetchArtwork()"><i-lucide name="image-down" [size]="16"></i-lucide>Fetch artwork</a>
         </li>
         <li>
-          <a (click)="openCfg()"
-            ><i-lucide name="sliders-horizontal" [size]="16"></i-lucide>Game settings</a
-          >
+          <a (click)="openCfg()"><i-lucide name="sliders-horizontal" [size]="16"></i-lucide>Game settings</a>
         </li>
         }
         @if(canCompressZso()) {
         <li>
-          <a (click)="convertToZso()"
-            ><i-lucide name="file-archive" [size]="16"></i-lucide>Convert to ZSO</a
-          >
+          <a (click)="convertToZso()"><i-lucide name="file-archive" [size]="16"></i-lucide>Convert to ZSO</a>
         </li>
         }
         @if(canRenameConvention()) {
         <li>
-          <a (click)="openRename()"
-            ><i-lucide name="text-cursor-input" [size]="16"></i-lucide>Rename to convention…</a
-          >
+          <a (click)="openRename()"><i-lucide name="text-cursor-input" [size]="16"></i-lucide>{{ game()?.isPs1Launcher ?
+            'Rename game…' : 'Rename to convention…' }}</a>
         </li>
         }
         <li>
-          <a class="text-error" (click)="confirmDelete()"
-            ><i-lucide name="trash-2" [size]="16"></i-lucide>Delete</a
-          >
+          <a class="text-error" (click)="confirmDelete()"><i-lucide name="trash-2" [size]="16"></i-lucide>Delete</a>
         </li>
       </ul>
     </div>
@@ -140,12 +113,11 @@
 }
 
 @if(showCfg && game()) {
-<app-game-cfg-dialog [game]="game()!" (closed)="showCfg = false"></app-game-cfg-dialog>
+<app-game-cfg-dialog [game]="game()!"
+  (closed)="showCfg = false; _libraryService.refreshGamesFiles()"></app-game-cfg-dialog>
 }
 
 @if(showRename && game()) {
-<app-library-rename-dialog
-  [game]="game()!"
-  (closed)="showRename = false"
-></app-library-rename-dialog>
+<app-library-rename-dialog [game]="game()!"
+  (closed)="showRename = false; _libraryService.refreshGamesFiles()"></app-library-rename-dialog>
 }

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.html
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.html
@@ -18,7 +18,7 @@
   <span class="chip chip-region font-mono">{{ game()?.region }}</span>
   }
   <span class="row-meta font-mono">{{ game()?.size }}</span>
-  <span class="chip font-mono">{{ game()?.system === 'APPS' && !game()?.isPs1Launcher ? 'ELF' : (game()?.format || game()?.extension) }}</span>
+  <span class="chip font-mono">{{ formatLabel() }}</span>
   <div class="dropdown dropdown-end row-actions">
     <div tabindex="0" role="button" class="btn btn-sm btn-ghost btn-square">
       <i-lucide name="ellipsis-vertical" size="16"></i-lucide>
@@ -108,7 +108,7 @@
         @if(!isApp()) {
         <span class="chip chip-region font-mono">{{ game()?.region }}</span>
         }
-        <span class="chip font-mono">{{ game()?.system === 'APPS' && !game()?.isPs1Launcher ? 'ELF' : (game()?.format || game()?.extension) }}</span>
+        <span class="chip font-mono">{{ formatLabel() }}</span>
         <span class="poster-size font-mono">{{ game()?.size }}</span>
       </div>
     </div>

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.scss
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.scss
@@ -19,6 +19,12 @@
      beyond the tile bounds. Image clipping lives on the inner wrapper. */
 }
 
+/* PS1 launcher apps (shown in APPS section for OPL 1.2+) use square tiles
+   so they visually differentiate from standard disc-game posters. */
+.poster-art.is-square {
+  aspect-ratio: 1 / 1;
+}
+
 .poster-art-clip {
   position: absolute;
   inset: 0;
@@ -75,6 +81,11 @@
 .poster-system.is-ps1 {
   background: oklch(60% 0.17 287 / 0.85);
   box-shadow: 0 2px 8px -2px oklch(60% 0.17 287 / 0.8);
+}
+
+.poster-system.is-ps1-app {
+  background: oklch(66.696% 0.11697 186.07);
+  box-shadow: 0 2px 8px -2px #00ab9f;
 }
 
 /* Kebab menu — fades in on hover */

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.scss
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.scss
@@ -85,7 +85,7 @@
 
 .poster-system.is-ps1-app {
   background: oklch(66.696% 0.11697 186.07);
-  box-shadow: 0 2px 8px -2px #00ab9f;
+  box-shadow: 0 2px 8px -2px oklch(66.696% 0.11697 186.07 / 0.8);
 }
 
 /* Kebab menu — fades in on hover */

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -96,6 +96,7 @@ export class GamecardComponent {
   public showRename = false;
   public showDeleteDialog = false;
   public showAppDeleteDialog = false;
+  public deleteArtwork = false;
 
   private readonly _cdr = inject(ChangeDetectorRef);
 
@@ -162,27 +163,31 @@ export class GamecardComponent {
     const g = this.game();
     if (!g) return;
     if (g.isPs1Launcher) {
-      const confirmed = await this._confirm.confirm({
+      const result = await this._confirm.confirmWithCheckbox({
         title: 'Delete PS1 Game',
         message: `Delete PS1 game "${g.title}"?`,
         detail:
           'This removes the VCD file, launcher app and POPS subfolder elements (VMCs, CHEATS.TXT, etc.)',
         confirmLabel: 'Delete',
+        checkboxLabel: 'Also delete game artwork',
       });
-      if (confirmed) {
+      if (result.confirmed) {
+        this.deleteArtwork = result.checked;
         this.showDeleteDialog = true;
         this._cdr.markForCheck();
       }
       return;
     }
     if (this.isApp()) {
-      const confirmed = await this._confirm.confirm({
+      const result = await this._confirm.confirmWithCheckbox({
         title: 'Delete App',
         message: `Delete the app "${g.title}"?`,
-        detail: 'This removes its APPS folder, files and associated artwork.',
+        detail: 'This removes its APPS folder and all files inside.',
         confirmLabel: 'Delete',
+        checkboxLabel: 'Also delete game artwork',
       });
-      if (confirmed) {
+      if (result.confirmed) {
+        this.deleteArtwork = result.checked;
         this.showAppDeleteDialog = true;
         this._cdr.markForCheck();
       }

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -132,7 +132,7 @@ export class GamecardComponent {
         title: 'Delete PS1 Game',
         message: `Delete PS1 game "${g.title}"?`,
         detail:
-          'This removes the VCD file, launcher app, POPS subfolder (VMCs, configs), and artwork.',
+          'This removes the VCD file, launcher app and POPS subfolder elements (VMCs, CHEATS.TXT, etc.)',
         confirmLabel: 'Delete',
       });
       if (confirmed) this.showDeleteDialog = true;

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -1,7 +1,9 @@
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   computed,
+  inject,
   input,
 } from '@angular/core';
 import { Game } from '@shared/types/game.type';
@@ -92,6 +94,8 @@ export class GamecardComponent {
   public showRename = false;
   public showDeleteDialog = false;
 
+  private readonly _cdr = inject(ChangeDetectorRef);
+
   constructor(
     public readonly _libraryService: LibraryService,
     private readonly _jobs: JobsService,
@@ -159,7 +163,10 @@ export class GamecardComponent {
           'This removes the VCD file, launcher app and POPS subfolder elements (VMCs, CHEATS.TXT, etc.)',
         confirmLabel: 'Delete',
       });
-      if (confirmed) this.showDeleteDialog = true;
+      if (confirmed) {
+        this.showDeleteDialog = true;
+        this._cdr.markForCheck();
+      }
       return;
     }
     if (this.isApp()) {

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -1,5 +1,10 @@
-import { Component, computed, input } from '@angular/core';
-import { Game, gameArt } from '@shared/types/game.type';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+import { Game } from '@shared/types/game.type';
 
 import { LibraryService } from '@shared/services/library.service';
 import { JobsService } from '@shared/services/jobs.service';
@@ -21,6 +26,7 @@ export type GamecardViewMode = 'grid' | 'list';
   ],
   templateUrl: './gamecard.component.html',
   styleUrl: './gamecard.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GamecardComponent {
   readonly game = input<Game | undefined>(undefined);
@@ -36,13 +42,28 @@ export class GamecardComponent {
     return undefined;
   });
 
-  readonly isApp = computed(
-    () => this.game()?.system === 'APPS' && !this.game()?.isPs1Launcher,
-  );
+  readonly artSrc = computed(() => {
+    const a = this.displayArt();
+    return a ? `data:image/png;base64,${a.base64}` : null;
+  });
 
-  readonly isPs1LauncherApp = computed(
-    () => this.game()?.system === 'APPS' && !!this.game()?.isPs1Launcher,
-  );
+  readonly displaySystemLabel = computed(() => {
+    const g = this.game();
+    if (g?.isPs1Launcher) return 'PS1 App';
+    if (g?.system === 'PS1') return 'PS1';
+    if (g?.system === 'APPS') return 'APP';
+    return 'PS2';
+  });
+
+  readonly isApp = computed(() => {
+    const g = this.game();
+    return g?.system === 'APPS' && !g?.isPs1Launcher;
+  });
+
+  readonly isPs1LauncherApp = computed(() => {
+    const g = this.game();
+    return g?.system === 'APPS' && !!g?.isPs1Launcher;
+  });
 
   readonly canCompressZso = computed(() => {
     const g = this.game();
@@ -103,13 +124,16 @@ export class GamecardComponent {
     ]);
   }
 
-  convertToZso() {
+  async convertToZso() {
     const g = this.game();
     if (!g || !this.canCompressZso()) return;
-    const confirmed = window.confirm(
-      `Compress "${g.title || g.gameId}" to ZSO?\n\n` +
-        `This creates a smaller .zso and removes the original .iso once it succeeds.`,
-    );
+    const confirmed = await this._confirm.confirm({
+      title: 'Convert to ZSO',
+      message: `Compress "${g.title || g.gameId}" to ZSO?`,
+      detail:
+        'This creates a smaller .zso and removes the original .iso once it succeeds.',
+      confirmLabel: 'Convert',
+    });
     if (!confirmed) return;
     this._jobs.enqueue([
       {

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -53,6 +53,9 @@ export class GamecardComponent {
   readonly canRenameConvention = computed(() => {
     const g = this.game();
     if (!g) return false;
+    if (g.isPs1Launcher) {
+      return !!g.path && !!g.gameId && !!g.title;
+    }
     const system = g.system ?? 'PS2';
     return (
       system === 'PS2' &&

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -1,8 +1,9 @@
-import { Component, Input, OnChanges, OnInit, SimpleChanges } from '@angular/core';
+import { Component, computed, input } from '@angular/core';
 import { Game, gameArt } from '../../../../shared/types/game.type';
 
 import { LibraryService } from '../../../../shared/services/library.service';
 import { JobsService } from '../../../../shared/services/jobs.service';
+import { ConfirmDialogService } from '../../../../shared/services/confirm-dialog.service';
 import { LucideAngularModule } from 'lucide-angular';
 import { GameCfgDialogComponent } from '../game-cfg-dialog/game-cfg-dialog.component';
 import { LibraryRenameDialogComponent } from '../rename-dialog/rename-dialog.component';
@@ -19,124 +20,140 @@ export type GamecardViewMode = 'grid' | 'list';
   templateUrl: './gamecard.component.html',
   styleUrl: './gamecard.component.scss',
 })
-export class GamecardComponent implements OnInit, OnChanges {
-  @Input() game: Game | undefined;
-  @Input() viewMode: GamecardViewMode = 'grid';
+export class GamecardComponent {
+  readonly game = input<Game | undefined>(undefined);
+  readonly viewMode = input<GamecardViewMode>('grid');
 
-  constructor(
-    public readonly _libraryService: LibraryService,
-    private readonly _jobs: JobsService
-  ) {}
+  readonly displayArt = computed(() => {
+    const g = this.game();
+    const vm = this.viewMode();
+    if (g && Array.isArray(g.art)) {
+      const artType = vm === 'list' ? 'ICO' : 'COV';
+      return g.art.find((a) => a.type?.toUpperCase() === artType);
+    }
+    return undefined;
+  });
 
-  /** Homebrew apps are managed differently from disc games. */
-  get isApp(): boolean {
-    return this.game?.system === 'APPS';
-  }
+  readonly isApp = computed(
+    () => this.game()?.system === 'APPS' && !this.game()?.isPs1Launcher,
+  );
 
-  /** Only PS2 ISO images can be compressed to ZSO. */
-  get canCompressZso(): boolean {
-    if (!this.game) return false;
-    const system = this.game.system ?? 'PS2';
-    const isIso =
-      this.game.format === 'ISO' ||
-      this.game.extension?.toLowerCase() === 'iso';
+  readonly isPs1LauncherApp = computed(
+    () => this.game()?.system === 'APPS' && !!this.game()?.isPs1Launcher,
+  );
+
+  readonly canCompressZso = computed(() => {
+    const g = this.game();
+    if (!g) return false;
+    const system = g.system ?? 'PS2';
+    const isIso = g.format === 'ISO' || g.extension?.toLowerCase() === 'iso';
     return system === 'PS2' && isIso;
-  }
+  });
 
-  /** Old/new naming convention only applies to PS2 disc images. */
-  get canRenameConvention(): boolean {
-    if (!this.game) return false;
-    const system = this.game.system ?? 'PS2';
+  readonly canRenameConvention = computed(() => {
+    const g = this.game();
+    if (!g) return false;
+    const system = g.system ?? 'PS2';
     return (
       system === 'PS2' &&
-      (this.game.format === 'ISO' || this.game.format === 'ZSO') &&
-      !!this.game.gameId &&
-      !!this.game.title
+      (g.format === 'ISO' || g.format === 'ZSO') &&
+      !!g.gameId &&
+      !!g.title
     );
-  }
+  });
 
-  public displayArt: gameArt | undefined;
   public showCfg = false;
   public showRename = false;
 
+  constructor(
+    public readonly _libraryService: LibraryService,
+    private readonly _jobs: JobsService,
+    private readonly _confirm: ConfirmDialogService,
+  ) {}
+
   openCfg() {
-    if (this.game) this.showCfg = true;
+    if (this.game()) this.showCfg = true;
   }
 
   openRename() {
-    if (this.game) this.showRename = true;
-  }
-
-  ngOnInit() {
-    this.updateDisplayArt();
-  }
-
-  ngOnChanges(changes: SimpleChanges) {
-    if (changes['game'] || changes['viewMode']) {
-      this.updateDisplayArt();
-    }
-  }
-
-  private updateDisplayArt() {
-    if (this.game && Array.isArray(this.game.art)) {
-      const artType = this.viewMode === 'list' ? 'ICO' : 'COV';
-      this.displayArt = this.game.art.find(
-        (a) => a.type?.toUpperCase() === artType
-      );
-    } else {
-      this.displayArt = undefined;
-    }
+    if (this.game()) this.showRename = true;
   }
 
   fetchArtwork() {
-    if (!this.game || this.isApp) return;
+    const g = this.game();
+    if (!g) return;
+    if (this.isApp()) return;
     this._jobs.enqueue([
       {
         type: 'artwork',
-        label: this.game.title || this.game.gameId || this.game.filename,
-        filePath: this.game.path,
-        gameId: this.game.gameId,
-        gameName: this.game.title || '',
+        label: g.title || g.gameId || g.filename,
+        filePath: g.path,
+        gameId: g.gameId,
+        gameName: g.title || '',
         downloadArtwork: false,
-        system: this.game.system === 'PS1' ? 'PS1' : 'PS2',
+        system: this.isPs1LauncherApp()
+          ? 'PS1'
+          : g.system === 'PS1'
+            ? 'PS1'
+            : 'PS2',
+        saveAsName: this.isPs1LauncherApp() ? g.ps1LauncherBoot : undefined,
       },
     ]);
   }
 
   convertToZso() {
-    if (!this.game || !this.canCompressZso) return;
+    const g = this.game();
+    if (!g || !this.canCompressZso()) return;
     const confirmed = window.confirm(
-      `Compress "${this.game.title || this.game.gameId}" to ZSO?\n\n` +
-        `This creates a smaller .zso and removes the original .iso once it succeeds.`
+      `Compress "${g.title || g.gameId}" to ZSO?\n\n` +
+        `This creates a smaller .zso and removes the original .iso once it succeeds.`,
     );
     if (!confirmed) return;
     this._jobs.enqueue([
       {
         type: 'zso',
-        label: this.game.title || this.game.gameId || this.game.filename,
-        filePath: this.game.path,
-        gameId: this.game.gameId,
-        gameName: this.game.title || '',
+        label: g.title || g.gameId || g.filename,
+        filePath: g.path,
+        gameId: g.gameId,
+        gameName: g.title || '',
         downloadArtwork: false,
         deleteOriginal: true,
       },
     ]);
   }
 
-  confirmDelete() {
-    if (!this.game) return;
-    if (this.isApp) {
-      const confirmed = window.confirm(
-        `Delete the app "${this.game.title}"?\nThis removes its APPS folder.`
-      );
-      if (confirmed) this._libraryService.deleteApp(this.game);
+  async confirmDelete() {
+    const g = this.game();
+    if (!g) return;
+    if (g.isPs1Launcher) {
+      const confirmed = await this._confirm.confirm({
+        title: 'Delete PS1 Game',
+        message: `Delete PS1 game "${g.title}"?`,
+        detail:
+          'This removes the VCD file, its launcher app, and associated artwork.',
+        confirmLabel: 'Delete',
+      });
+      if (confirmed) this._libraryService.deleteGame(g);
       return;
     }
-    const confirmed = window.confirm(
-      `Are you sure you want to delete "${this.game.title || this.game.gameId}"?\nThis will also remove associated artwork.`
-    );
+    if (this.isApp()) {
+      const confirmed = await this._confirm.confirm({
+        title: 'Delete App',
+        message: `Delete the app "${g.title}"?`,
+        detail: 'This removes its APPS folder.',
+        confirmLabel: 'Delete',
+      });
+      if (confirmed) this._libraryService.deleteApp(g);
+      return;
+    }
+    const confirmed = await this._confirm.confirm({
+      title: 'Delete Game',
+      message: `Are you sure you want to delete "${g.title || g.gameId}"?`,
+      detail: 'This will also remove associated artwork.',
+      confirmLabel: 'Delete',
+    });
     if (confirmed) {
-      this._libraryService.deleteGame(this.game);
+      this._libraryService.deleteGame(g);
     }
   }
 }

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -69,6 +69,12 @@ export class GamecardComponent {
     return g?.system === 'APPS' && !!g?.isPs1Launcher;
   });
 
+  readonly formatLabel = computed(() => {
+    const g = this.game();
+    if (g?.system === 'APPS' && !g?.isPs1Launcher) return 'ELF';
+    return g?.format || g?.extension || '';
+  });
+
   readonly canCompressZso = computed(() => {
     const g = this.game();
     if (!g) return false;
@@ -169,7 +175,7 @@ export class GamecardComponent {
         detail:
           'This removes the VCD file, launcher app and POPS subfolder elements (VMCs, CHEATS.TXT, etc.)',
         confirmLabel: 'Delete',
-        checkboxLabel: 'Also delete game artwork',
+        toggleLabel: 'Also delete game artwork',
       });
       if (result.confirmed) {
         this.deleteArtwork = result.checked;
@@ -184,7 +190,7 @@ export class GamecardComponent {
         message: `Delete the app "${g.title}"?`,
         detail: 'This removes its APPS folder and all files inside.',
         confirmLabel: 'Delete',
-        checkboxLabel: 'Also delete game artwork',
+        toggleLabel: 'Also delete game artwork',
       });
       if (result.confirmed) {
         this.deleteArtwork = result.checked;

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -7,6 +7,7 @@ import { ConfirmDialogService } from '../../../../shared/services/confirm-dialog
 import { LucideAngularModule } from 'lucide-angular';
 import { GameCfgDialogComponent } from '../game-cfg-dialog/game-cfg-dialog.component';
 import { LibraryRenameDialogComponent } from '../rename-dialog/rename-dialog.component';
+import { Ps1DeleteDialogComponent } from '../ps1-delete-dialog/ps1-delete-dialog.component';
 
 export type GamecardViewMode = 'grid' | 'list';
 
@@ -16,6 +17,7 @@ export type GamecardViewMode = 'grid' | 'list';
     LucideAngularModule,
     GameCfgDialogComponent,
     LibraryRenameDialogComponent,
+    Ps1DeleteDialogComponent,
   ],
   templateUrl: './gamecard.component.html',
   styleUrl: './gamecard.component.scss',
@@ -67,6 +69,7 @@ export class GamecardComponent {
 
   public showCfg = false;
   public showRename = false;
+  public showDeleteDialog = false;
 
   constructor(
     public readonly _libraryService: LibraryService,
@@ -133,10 +136,10 @@ export class GamecardComponent {
         title: 'Delete PS1 Game',
         message: `Delete PS1 game "${g.title}"?`,
         detail:
-          'This removes the VCD file and its launcher app.',
+          'This removes the VCD file, launcher app, VMC folder, and artwork.',
         confirmLabel: 'Delete',
       });
-      if (confirmed) this._libraryService.deleteGame(g);
+      if (confirmed) this.showDeleteDialog = true;
       return;
     }
     if (this.isApp()) {

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -19,6 +19,13 @@ import { AppDeleteDialogComponent } from '../app-delete-dialog/app-delete-dialog
 
 export type GamecardViewMode = 'grid' | 'list';
 
+/**
+ * Displays a single game in either grid or list view.
+ *
+ * Handles artwork rendering, system badges, format labels, and all
+ * game-specific actions: configuration editing, renaming, artwork
+ * fetching, ZSO compression, and deletion (PS2 / PS1 / App variants).
+ */
 @Component({
   selector: 'app-gamecard',
   imports: [
@@ -33,9 +40,15 @@ export type GamecardViewMode = 'grid' | 'list';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class GamecardComponent {
+  /** The game data to render — undefined while the library is loading. */
   readonly game = input<Game | undefined>(undefined);
+
+  /** Whether the library is currently in grid or list view. */
   readonly viewMode = input<GamecardViewMode>('grid');
 
+  // ── Artwork ──────────────────────────────────────────────────────────
+
+  /** The best art asset for the current view mode (ICO in list, COV in grid). */
   readonly displayArt = computed(() => {
     const g = this.game();
     const vm = this.viewMode();
@@ -46,11 +59,15 @@ export class GamecardComponent {
     return undefined;
   });
 
+  /** Base64 data-URL of the selected artwork, or null if none found. */
   readonly artSrc = computed(() => {
     const a = this.displayArt();
     return a ? `data:image/png;base64,${a.base64}` : null;
   });
 
+  // ── Labels & badges ──────────────────────────────────────────────────
+
+  /** Human-readable system label for the badge chip. */
   readonly displaySystemLabel = computed(() => {
     const g = this.game();
     if (g?.isPs1Launcher) return 'PS1 App';
@@ -59,22 +76,28 @@ export class GamecardComponent {
     return 'PS2';
   });
 
+  /** Whether this game is a regular (non-PS1-launcher) ELF app. */
   readonly isApp = computed(() => {
     const g = this.game();
     return g?.system === 'APPS' && !g?.isPs1Launcher;
   });
 
+  /** Whether this game is a PS1 launcher app. */
   readonly isPs1LauncherApp = computed(() => {
     const g = this.game();
     return g?.system === 'APPS' && !!g?.isPs1Launcher;
   });
 
+  /** Format label shown in the chip — "ELF" for regular apps, otherwise format/extension. */
   readonly formatLabel = computed(() => {
     const g = this.game();
     if (g?.system === 'APPS' && !g?.isPs1Launcher) return 'ELF';
     return g?.format || g?.extension || '';
   });
 
+  // ── Action availability ──────────────────────────────────────────────
+
+  /** Whether a PS2 ISO can be compressed to ZSO. */
   readonly canCompressZso = computed(() => {
     const g = this.game();
     if (!g) return false;
@@ -83,6 +106,7 @@ export class GamecardComponent {
     return system === 'PS2' && isIso;
   });
 
+  /** Whether the file can be renamed to the OPL naming convention. */
   readonly canRenameConvention = computed(() => {
     const g = this.game();
     if (!g) return false;
@@ -98,10 +122,21 @@ export class GamecardComponent {
     );
   });
 
+  // ── Dialog visibility state ──────────────────────────────────────────
+
+  /** Whether the game-config dialog is open. */
   public showCfg = false;
+
+  /** Whether the rename dialog is open. */
   public showRename = false;
+
+  /** Whether the PS1 delete-progress dialog is open. */
   public showDeleteDialog = false;
+
+  /** Whether the App delete-progress dialog is open. */
   public showAppDeleteDialog = false;
+
+  /** Whether the user opted to delete artwork alongside the game. */
   public deleteArtwork = false;
 
   private readonly _cdr = inject(ChangeDetectorRef);
@@ -112,10 +147,14 @@ export class GamecardComponent {
     private readonly _confirm: ConfirmDialogService,
   ) {}
 
+  // ── Actions ──────────────────────────────────────────────────────────
+
+  /** Open the game configuration editor dialog. */
   openCfg() {
     if (this.game()) this.showCfg = true;
   }
 
+  /** Open the rename dialog to rename the game file. */
   openRename() {
     if (this.game()) {
       this.showRename = true;
@@ -123,6 +162,10 @@ export class GamecardComponent {
     }
   }
 
+  /**
+   * Enqueue an artwork-fetch job for this game.
+   * Regular ELF apps are skipped — they have no artwork source.
+   */
   fetchArtwork() {
     const g = this.game();
     if (!g) return;
@@ -141,6 +184,7 @@ export class GamecardComponent {
     ]);
   }
 
+  /** Enqueue a ZSO compression job for a PS2 ISO. */
   async convertToZso() {
     const g = this.game();
     if (!g || !this.canCompressZso()) return;
@@ -165,6 +209,12 @@ export class GamecardComponent {
     ]);
   }
 
+  /**
+   * Show the appropriate delete confirmation dialog based on game type:
+   *   - PS1 launcher → confirm-with-checkbox then PS1 delete dialog
+   *   - Regular app   → confirm-with-checkbox then App delete dialog
+   *   - PS2 game       → simple confirm then immediate delete
+   */
   async confirmDelete() {
     const g = this.game();
     if (!g) return;

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -97,11 +97,7 @@ export class GamecardComponent {
         gameId: g.gameId,
         gameName: g.title || '',
         downloadArtwork: false,
-        system: this.isPs1LauncherApp()
-          ? 'PS1'
-          : g.system === 'PS1'
-            ? 'PS1'
-            : 'PS2',
+        system: g.system === 'PS1' || this.isPs1LauncherApp() ? 'PS1' : 'PS2',
         saveAsName: this.isPs1LauncherApp() ? g.ps1LauncherBoot : undefined,
       },
     ]);
@@ -136,7 +132,7 @@ export class GamecardComponent {
         title: 'Delete PS1 Game',
         message: `Delete PS1 game "${g.title}"?`,
         detail:
-          'This removes the VCD file, launcher app, VMC folder, and artwork.',
+          'This removes the VCD file, launcher app, POPS subfolder (VMCs, configs), and artwork.',
         confirmLabel: 'Delete',
       });
       if (confirmed) this.showDeleteDialog = true;

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -1,9 +1,9 @@
 import { Component, computed, input } from '@angular/core';
-import { Game, gameArt } from '../../../../shared/types/game.type';
+import { Game, gameArt } from '@shared/types/game.type';
 
-import { LibraryService } from '../../../../shared/services/library.service';
-import { JobsService } from '../../../../shared/services/jobs.service';
-import { ConfirmDialogService } from '../../../../shared/services/confirm-dialog.service';
+import { LibraryService } from '@shared/services/library.service';
+import { JobsService } from '@shared/services/jobs.service';
+import { ConfirmDialogService } from '@shared/services/confirm-dialog.service';
 import { LucideAngularModule } from 'lucide-angular';
 import { GameCfgDialogComponent } from '../game-cfg-dialog/game-cfg-dialog.component';
 import { LibraryRenameDialogComponent } from '../rename-dialog/rename-dialog.component';

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -15,6 +15,7 @@ import { LucideAngularModule } from 'lucide-angular';
 import { GameCfgDialogComponent } from '../game-cfg-dialog/game-cfg-dialog.component';
 import { LibraryRenameDialogComponent } from '../rename-dialog/rename-dialog.component';
 import { Ps1DeleteDialogComponent } from '../ps1-delete-dialog/ps1-delete-dialog.component';
+import { AppDeleteDialogComponent } from '../app-delete-dialog/app-delete-dialog.component';
 
 export type GamecardViewMode = 'grid' | 'list';
 
@@ -25,6 +26,7 @@ export type GamecardViewMode = 'grid' | 'list';
     GameCfgDialogComponent,
     LibraryRenameDialogComponent,
     Ps1DeleteDialogComponent,
+    AppDeleteDialogComponent,
   ],
   templateUrl: './gamecard.component.html',
   styleUrl: './gamecard.component.scss',
@@ -93,6 +95,7 @@ export class GamecardComponent {
   public showCfg = false;
   public showRename = false;
   public showDeleteDialog = false;
+  public showAppDeleteDialog = false;
 
   private readonly _cdr = inject(ChangeDetectorRef);
 
@@ -176,10 +179,13 @@ export class GamecardComponent {
       const confirmed = await this._confirm.confirm({
         title: 'Delete App',
         message: `Delete the app "${g.title}"?`,
-        detail: 'This removes its APPS folder.',
+        detail: 'This removes its APPS folder, files and associated artwork.',
         confirmLabel: 'Delete',
       });
-      if (confirmed) this._libraryService.deleteApp(g);
+      if (confirmed) {
+        this.showAppDeleteDialog = true;
+        this._cdr.markForCheck();
+      }
       return;
     }
     const confirmed = await this._confirm.confirm({

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -133,7 +133,7 @@ export class GamecardComponent {
         title: 'Delete PS1 Game',
         message: `Delete PS1 game "${g.title}"?`,
         detail:
-          'This removes the VCD file, its launcher app, and associated artwork.',
+          'This removes the VCD file and its launcher app.',
         confirmLabel: 'Delete',
       });
       if (confirmed) this._libraryService.deleteGame(g);

--- a/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
+++ b/angular/src/app/pages/library/components/gamecard/gamecard.component.ts
@@ -107,7 +107,10 @@ export class GamecardComponent {
   }
 
   openRename() {
-    if (this.game()) this.showRename = true;
+    if (this.game()) {
+      this.showRename = true;
+      this._cdr.markForCheck();
+    }
   }
 
   fetchArtwork() {

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.html
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.html
@@ -6,6 +6,9 @@
       @if (deleting) { Deleting PS1 App Game… }
       @else { Delete complete }
     </h2>
+    <button class="btn btn-ghost btn-xs btn-square ml-auto" (click)="close()" [disabled]="deleting">
+      <i-lucide name="x" size="16"></i-lucide>
+    </button>
   </div>
 
   <div class="delete-body flex flex-col gap-4 px-5 py-4">
@@ -14,7 +17,7 @@
       <span class="ml-2 text-xs text-base-content/50">{{ game().gameId }}</span>
     </div>
 
-    <div class="log-area rounded-md border border-base-content/10 bg-base-100/30">
+    <div #logArea class="log-area rounded-md border border-base-content/10 bg-base-100/30">
       @if (deleting && entries.length === 0) {
       <div class="flex items-center gap-2 p-4 text-sm text-base-content/60">
         <span class="loading loading-spinner loading-sm"></span>

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.html
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.html
@@ -10,17 +10,17 @@
 
   <div class="delete-body flex flex-col gap-4 px-5 py-4">
     <div class="rounded-md border border-base-content/10 bg-base-100/30 p-3 text-sm">
-      <span class="font-semibold">{{ game.title || game.gameId }}</span>
-      <span class="ml-2 text-xs text-base-content/50">{{ game.gameId }}</span>
+      <span class="font-semibold">{{ game().title || game().gameId }}</span>
+      <span class="ml-2 text-xs text-base-content/50">{{ game().gameId }}</span>
     </div>
 
+    @if (deleting) {
+    <div class="flex items-center gap-2 p-4 text-sm text-base-content/60">
+      <span class="loading loading-spinner loading-sm"></span>
+      Deleting…
+    </div>
+    } @else {
     <div class="log-area rounded-md border border-base-content/10 bg-base-100/30">
-      @if (deleting) {
-      <div class="flex items-center gap-2 p-4 text-sm text-base-content/60">
-        <span class="loading loading-spinner loading-sm"></span>
-        Deleting…
-      </div>
-      } @else {
       @for (entry of entries; track entry.label) {
       <div class="log-entry" [class.is-success]="entry.success" [class.is-error]="!entry.success">
         <div class="log-primary">
@@ -45,10 +45,8 @@
         }
       </div>
       }
-      }
     </div>
 
-    @if (!deleting) {
     <div class="rounded-md border p-3 text-sm" [class.border-success/30]="overallSuccess"
       [class.bg-success/5]="overallSuccess" [class.border-error/30]="!overallSuccess"
       [class.bg-error/5]="!overallSuccess">

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.html
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.html
@@ -1,0 +1,94 @@
+<div class="delete-backdrop" (click)="deleting ? null : close()"></div>
+<div class="delete-modal glass-strong" role="dialog">
+  <div class="flex items-center gap-2 border-b border-base-content/10 px-5 py-3">
+    <i-lucide name="trash-2" size="18" class="text-error"></i-lucide>
+    <h2 class="font-display text-sm font-semibold tracking-wide">
+      @if (deleting) { Deleting PS1 App Game… }
+      @else { Delete complete }
+    </h2>
+    <button class="btn btn-ghost btn-xs btn-square ml-auto" (click)="close()" [disabled]="deleting">
+      <i-lucide name="x" size="16"></i-lucide>
+    </button>
+  </div>
+
+  <div class="delete-body flex flex-col gap-4 px-5 py-4">
+    <div class="rounded-md border border-base-content/10 bg-base-100/30 p-3 text-sm">
+      <span class="font-semibold">{{ game.title || game.gameId }}</span>
+      <span class="ml-2 text-xs text-base-content/50">{{ game.gameId }}</span>
+    </div>
+
+    <div
+      class="log-area rounded-md border border-base-content/10 bg-base-100/30"
+    >
+      @if (deleting) {
+        <div class="flex items-center gap-2 p-4 text-sm text-base-content/60">
+          <span class="loading loading-spinner loading-sm"></span>
+          Deleting…
+        </div>
+      } @else {
+        @for (entry of entries; track entry.label) {
+          <div
+            class="log-entry"
+            [class.is-success]="entry.success"
+            [class.is-error]="!entry.success"
+          >
+            <div class="log-primary">
+              <span class="entry-icon">
+                @if (entry.success) {
+                  <i-lucide name="circle-check" size="14"></i-lucide>
+                } @else {
+                  <i-lucide name="circle-x" size="14"></i-lucide>
+                }
+              </span>
+              <span class="entry-label">{{ entry.label }}</span>
+            </div>
+            <div class="log-secondary">
+              @if (entry.path && entry.path !== 'Not present') {
+                <span class="entry-path font-mono">{{ entry.path }}</span>
+              } @else if (entry.path === 'Not present') {
+                <span class="entry-path-missing font-mono italic">Not present</span>
+              }
+            </div>
+            @if (!entry.success && entry.error) {
+              <div class="log-error-detail font-mono text-xs">{{ entry.error }}</div>
+            }
+          </div>
+        }
+      }
+    </div>
+
+    @if (!deleting) {
+      <div
+        class="rounded-md border p-3 text-sm"
+        [class.border-success/30]="overallSuccess"
+        [class.bg-success/5]="overallSuccess"
+        [class.border-error/30]="!overallSuccess"
+        [class.bg-error/5]="!overallSuccess"
+      >
+        <div class="flex items-center gap-2">
+          <i-lucide [name]="overallSuccess ? 'circle-check' : 'triangle-alert'" size="18"
+            [class.text-success]="overallSuccess" [class.text-error]="!overallSuccess"></i-lucide>
+          <span class="font-semibold">
+            {{ overallSuccess ? 'Deleted successfully' : 'Some items failed' }}
+          </span>
+        </div>
+        @if (!overallSuccess) {
+          <p class="mt-1 text-xs text-base-content/60">
+            The game may still be partially removed. Check the Logs page for details.
+          </p>
+        }
+      </div>
+    }
+  </div>
+
+  <div class="flex justify-end gap-2 border-t border-base-content/10 px-5 py-3">
+    @if (deleting) {
+      <span class="text-xs text-base-content/40">Deleting — do not close…</span>
+    } @else {
+      <button class="btn btn-primary btn-sm" (click)="close()">
+        <i-lucide name="x" size="15"></i-lucide>
+        Close
+      </button>
+    }
+  </div>
+</div>

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.html
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.html
@@ -1,4 +1,4 @@
-<div class="delete-backdrop"></div>
+<div class="delete-backdrop" (click)="deleting ? null : close()"></div>
 <div class="delete-modal glass-strong" role="dialog">
   <div class="flex items-center gap-2 border-b border-base-content/10 px-5 py-3">
     <i-lucide name="trash-2" size="18" class="text-error"></i-lucide>
@@ -14,14 +14,14 @@
       <span class="ml-2 text-xs text-base-content/50">{{ game().gameId }}</span>
     </div>
 
-    @if (deleting) {
-    <div class="flex items-center gap-2 p-4 text-sm text-base-content/60">
-      <span class="loading loading-spinner loading-sm"></span>
-      Deleting…
-    </div>
-    } @else {
     <div class="log-area rounded-md border border-base-content/10 bg-base-100/30">
-      @for (entry of entries; track entry.label) {
+      @if (deleting && entries.length === 0) {
+      <div class="flex items-center gap-2 p-4 text-sm text-base-content/60">
+        <span class="loading loading-spinner loading-sm"></span>
+        Deleting…
+      </div>
+      }
+      @for (entry of entries; track entry.id) {
       <div class="log-entry" [class.is-success]="entry.success" [class.is-error]="!entry.success">
         <div class="log-primary">
           <span class="entry-icon">
@@ -47,6 +47,7 @@
       }
     </div>
 
+    @if (!deleting) {
     <div class="rounded-md border p-3 text-sm" [class.border-success/30]="overallSuccess"
       [class.bg-success/5]="overallSuccess" [class.border-error/30]="!overallSuccess"
       [class.bg-error/5]="!overallSuccess">

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.html
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.html
@@ -1,4 +1,4 @@
-<div class="delete-backdrop" (click)="deleting ? null : close()"></div>
+<div class="delete-backdrop"></div>
 <div class="delete-modal glass-strong" role="dialog">
   <div class="flex items-center gap-2 border-b border-base-content/10 px-5 py-3">
     <i-lucide name="trash-2" size="18" class="text-error"></i-lucide>
@@ -6,9 +6,6 @@
       @if (deleting) { Deleting PS1 App Game… }
       @else { Delete complete }
     </h2>
-    <button class="btn btn-ghost btn-xs btn-square ml-auto" (click)="close()" [disabled]="deleting">
-      <i-lucide name="x" size="16"></i-lucide>
-    </button>
   </div>
 
   <div class="delete-body flex flex-col gap-4 px-5 py-4">
@@ -17,78 +14,68 @@
       <span class="ml-2 text-xs text-base-content/50">{{ game.gameId }}</span>
     </div>
 
-    <div
-      class="log-area rounded-md border border-base-content/10 bg-base-100/30"
-    >
+    <div class="log-area rounded-md border border-base-content/10 bg-base-100/30">
       @if (deleting) {
-        <div class="flex items-center gap-2 p-4 text-sm text-base-content/60">
-          <span class="loading loading-spinner loading-sm"></span>
-          Deleting…
-        </div>
+      <div class="flex items-center gap-2 p-4 text-sm text-base-content/60">
+        <span class="loading loading-spinner loading-sm"></span>
+        Deleting…
+      </div>
       } @else {
-        @for (entry of entries; track entry.label) {
-          <div
-            class="log-entry"
-            [class.is-success]="entry.success"
-            [class.is-error]="!entry.success"
-          >
-            <div class="log-primary">
-              <span class="entry-icon">
-                @if (entry.success) {
-                  <i-lucide name="circle-check" size="14"></i-lucide>
-                } @else {
-                  <i-lucide name="circle-x" size="14"></i-lucide>
-                }
-              </span>
-              <span class="entry-label">{{ entry.label }}</span>
-            </div>
-            <div class="log-secondary">
-              @if (entry.path && entry.path !== 'Not present') {
-                <span class="entry-path font-mono">{{ entry.path }}</span>
-              } @else if (entry.path === 'Not present') {
-                <span class="entry-path-missing font-mono italic">Not present</span>
-              }
-            </div>
-            @if (!entry.success && entry.error) {
-              <div class="log-error-detail font-mono text-xs">{{ entry.error }}</div>
+      @for (entry of entries; track entry.label) {
+      <div class="log-entry" [class.is-success]="entry.success" [class.is-error]="!entry.success">
+        <div class="log-primary">
+          <span class="entry-icon">
+            @if (entry.success) {
+            <i-lucide name="circle-check" size="14"></i-lucide>
+            } @else {
+            <i-lucide name="circle-x" size="14"></i-lucide>
             }
-          </div>
+          </span>
+          <span class="entry-label">{{ entry.label }}</span>
+        </div>
+        <div class="log-secondary">
+          @if (entry.path && entry.path !== 'Not present') {
+          <span class="entry-path font-mono">{{ entry.path }}</span>
+          } @else if (entry.path === 'Not present') {
+          <span class="entry-path-missing font-mono italic">Not present</span>
+          }
+        </div>
+        @if (!entry.success && entry.error) {
+        <div class="log-error-detail font-mono text-xs">{{ entry.error }}</div>
         }
+      </div>
+      }
       }
     </div>
 
     @if (!deleting) {
-      <div
-        class="rounded-md border p-3 text-sm"
-        [class.border-success/30]="overallSuccess"
-        [class.bg-success/5]="overallSuccess"
-        [class.border-error/30]="!overallSuccess"
-        [class.bg-error/5]="!overallSuccess"
-      >
-        <div class="flex items-center gap-2">
-          <i-lucide [name]="overallSuccess ? 'circle-check' : 'triangle-alert'" size="18"
-            [class.text-success]="overallSuccess" [class.text-error]="!overallSuccess"></i-lucide>
-          <span class="font-semibold">
-            {{ overallSuccess ? 'Deleted successfully' : 'Some items failed' }}
-          </span>
-        </div>
-        @if (!overallSuccess) {
-          <p class="mt-1 text-xs text-base-content/60">
-            The game may still be partially removed. Check the Logs page for details.
-          </p>
-        }
+    <div class="rounded-md border p-3 text-sm" [class.border-success/30]="overallSuccess"
+      [class.bg-success/5]="overallSuccess" [class.border-error/30]="!overallSuccess"
+      [class.bg-error/5]="!overallSuccess">
+      <div class="flex items-center gap-2">
+        <i-lucide [name]="overallSuccess ? 'circle-check' : 'triangle-alert'" size="18"
+          [class.text-success]="overallSuccess" [class.text-error]="!overallSuccess"></i-lucide>
+        <span class="font-semibold">
+          {{ overallSuccess ? 'Deleted successfully' : 'Some items failed' }}
+        </span>
       </div>
+      @if (!overallSuccess) {
+      <p class="mt-1 text-xs text-base-content/60">
+        The game may still be partially removed. Check the Logs page for details.
+      </p>
+      }
+    </div>
     }
   </div>
 
   <div class="flex justify-end gap-2 border-t border-base-content/10 px-5 py-3">
     @if (deleting) {
-      <span class="text-xs text-base-content/40">Deleting — do not close…</span>
+    <span class="text-xs text-base-content/40">Deleting — do not close…</span>
     } @else {
-      <button class="btn btn-primary btn-sm" (click)="close()">
-        <i-lucide name="x" size="15"></i-lucide>
-        Close
-      </button>
+    <button class="btn btn-primary btn-sm" (click)="close()">
+      <i-lucide name="x" size="15"></i-lucide>
+      Close
+    </button>
     }
   </div>
 </div>

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.scss
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.scss
@@ -70,11 +70,11 @@
 }
 
 .log-entry.is-success .entry-icon {
-  color: #4ade80;
+  color: oklch(80.036% 0.18204 151.736);
 }
 
 .log-entry.is-error .entry-icon {
-  color: #f87171;
+  color: oklch(71.061% 0.16614 22.191);
 }
 
 .entry-label {
@@ -85,11 +85,11 @@
 }
 
 .log-entry.is-success .entry-label {
-  color: #4ade80;
+  color: oklch(80.036% 0.18204 151.736);
 }
 
 .log-entry.is-error .entry-label {
-  color: #f87171;
+  color: oklch(71.061% 0.16614 22.191);
 }
 
 .log-secondary {

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.scss
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.scss
@@ -1,0 +1,115 @@
+:host {
+  display: block;
+}
+
+.delete-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+}
+
+.delete-modal {
+  position: fixed;
+  z-index: 51;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(34rem, calc(100vw - 2rem));
+  max-height: calc(100vh - 4rem);
+  display: flex;
+  flex-direction: column;
+  border-radius: 1rem;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}
+
+.delete-body {
+  overflow-y: auto;
+  overflow-wrap: break-word;
+}
+
+/* ── Log area ──────────────────────────────────────────────── */
+
+.log-area {
+  overflow-y: auto;
+  max-height: 20rem;
+  font-size: 0.75rem;
+  line-height: 1.5;
+}
+
+.log-entry {
+  padding: 0.4rem 0.5rem;
+  border-bottom: 1px solid rgba(128, 128, 128, 0.08);
+}
+
+.log-entry:last-child {
+  border-bottom: none;
+}
+
+.log-entry.is-success {
+  background: rgba(74, 222, 128, 0.04);
+}
+
+.log-entry.is-error {
+  background: rgba(248, 113, 113, 0.06);
+}
+
+.log-primary {
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  margin-bottom: 0.15rem;
+}
+
+.entry-icon {
+  display: flex;
+  align-items: center;
+  flex-shrink: 0;
+}
+
+.log-entry.is-success .entry-icon {
+  color: #4ade80;
+}
+
+.log-entry.is-error .entry-icon {
+  color: #f87171;
+}
+
+.entry-label {
+  font-weight: 600;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.log-entry.is-success .entry-label {
+  color: #4ade80;
+}
+
+.log-entry.is-error .entry-label {
+  color: #f87171;
+}
+
+.log-secondary {
+  padding-left: 1.65rem;
+}
+
+.entry-path {
+  overflow-wrap: break-word;
+  word-break: break-all;
+  opacity: 0.75;
+  font-size: 0.65rem;
+}
+
+.entry-path-missing {
+  opacity: 0.35;
+  font-size: 0.65rem;
+}
+
+.log-error-detail {
+  padding-left: 1.65rem;
+  padding-top: 0.1rem;
+  opacity: 0.7;
+}

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.scss
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.scss
@@ -6,7 +6,7 @@
   position: fixed;
   inset: 0;
   z-index: 50;
-  background: rgba(0, 0, 0, 0.55);
+  background: oklch(0% 0 0 / 0.55);
   backdrop-filter: blur(2px);
 }
 
@@ -21,7 +21,7 @@
   display: flex;
   flex-direction: column;
   border-radius: 1rem;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 20px 60px oklch(0% 0 0 / 0.5);
   overflow: hidden;
 }
 
@@ -41,7 +41,7 @@
 
 .log-entry {
   padding: 0.4rem 0.5rem;
-  border-bottom: 1px solid rgba(128, 128, 128, 0.08);
+  border-bottom: 1px solid oklch(var(--bc) / 0.08);
 }
 
 .log-entry:last-child {
@@ -49,11 +49,11 @@
 }
 
 .log-entry.is-success {
-  background: rgba(74, 222, 128, 0.04);
+  background: oklch(var(--su) / 0.04);
 }
 
 .log-entry.is-error {
-  background: rgba(248, 113, 113, 0.06);
+  background: oklch(var(--er) / 0.06);
 }
 
 .log-primary {
@@ -70,11 +70,11 @@
 }
 
 .log-entry.is-success .entry-icon {
-  color: #4ade80;
+  color: var(--su);
 }
 
 .log-entry.is-error .entry-icon {
-  color: #f87171;
+  color: var(--er);
 }
 
 .entry-label {
@@ -85,11 +85,11 @@
 }
 
 .log-entry.is-success .entry-label {
-  color: #4ade80;
+  color: var(--su);
 }
 
 .log-entry.is-error .entry-label {
-  color: #f87171;
+  color: var(--er);
 }
 
 .log-secondary {

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.scss
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.scss
@@ -6,7 +6,7 @@
   position: fixed;
   inset: 0;
   z-index: 50;
-  background: oklch(0% 0 0 / 0.55);
+  background: rgba(0, 0, 0, 0.55);
   backdrop-filter: blur(2px);
 }
 
@@ -21,7 +21,7 @@
   display: flex;
   flex-direction: column;
   border-radius: 1rem;
-  box-shadow: 0 20px 60px oklch(0% 0 0 / 0.5);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
   overflow: hidden;
 }
 
@@ -41,7 +41,7 @@
 
 .log-entry {
   padding: 0.4rem 0.5rem;
-  border-bottom: 1px solid oklch(var(--bc) / 0.08);
+  border-bottom: 1px solid rgba(128, 128, 128, 0.08);
 }
 
 .log-entry:last-child {
@@ -49,11 +49,11 @@
 }
 
 .log-entry.is-success {
-  background: oklch(var(--su) / 0.04);
+  background: rgba(74, 222, 128, 0.04);
 }
 
 .log-entry.is-error {
-  background: oklch(var(--er) / 0.06);
+  background: rgba(248, 113, 113, 0.06);
 }
 
 .log-primary {
@@ -70,11 +70,11 @@
 }
 
 .log-entry.is-success .entry-icon {
-  color: var(--su);
+  color: #4ade80;
 }
 
 .log-entry.is-error .entry-icon {
-  color: var(--er);
+  color: #f87171;
 }
 
 .entry-label {
@@ -85,11 +85,11 @@
 }
 
 .log-entry.is-success .entry-label {
-  color: var(--su);
+  color: #4ade80;
 }
 
 .log-entry.is-error .entry-label {
-  color: var(--er);
+  color: #f87171;
 }
 
 .log-secondary {

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.scss
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.scss
@@ -104,7 +104,7 @@
 }
 
 .entry-path-missing {
-  opacity: 0.35;
+  opacity: 0.65;
   font-size: 0.65rem;
 }
 

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, input, output } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import { Game } from '@shared/types/game.type';
 import { LibraryService } from '@shared/services/library.service';
@@ -16,9 +16,9 @@ interface DeleteEntry {
   templateUrl: './ps1-delete-dialog.component.html',
   styleUrl: './ps1-delete-dialog.component.scss',
 })
-export class Ps1DeleteDialogComponent implements OnInit {
-  @Input({ required: true }) game!: Game;
-  @Output() closed = new EventEmitter<void>();
+export class Ps1DeleteDialogComponent {
+  readonly game = input.required<Game>();
+  readonly closed = output<void>();
 
   entries: DeleteEntry[] = [];
   deleting = true;
@@ -27,12 +27,19 @@ export class Ps1DeleteDialogComponent implements OnInit {
   constructor(private readonly _libraryService: LibraryService) {}
 
   async ngOnInit() {
-    const result = await this._libraryService.deleteGame(this.game, true);
-    if (result?.entries) {
-      this.entries = result.entries;
-      this.overallSuccess = !!result.success;
+    try {
+      const result = await this._libraryService.deleteGame(this.game(), true);
+      if (result?.entries) {
+        this.entries = result.entries;
+        this.overallSuccess = !!result.success;
+      }
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.entries = [{ label: 'Error', success: false, error: msg }];
+      this.overallSuccess = false;
+    } finally {
+      this.deleting = false;
     }
-    this.deleting = false;
   }
 
   close() {

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
@@ -1,24 +1,7 @@
-import {
-  ChangeDetectorRef,
-  Component,
-  DestroyRef,
-  ElementRef,
-  inject,
-  input,
-  output,
-  viewChild,
-} from '@angular/core';
+import { Component } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import { Game } from '@shared/types/game.type';
-import { LibraryService } from '@shared/services/library.service';
-
-interface DeleteEntry {
-  label: string;
-  path?: string;
-  success: boolean;
-  error?: string;
-  id?: number;
-}
+import { BaseDeleteDialogComponent, DeleteEntry } from '../delete-dialog-base';
 
 @Component({
   selector: 'app-ps1-delete-dialog',
@@ -26,79 +9,30 @@ interface DeleteEntry {
   templateUrl: './ps1-delete-dialog.component.html',
   styleUrl: './ps1-delete-dialog.component.scss',
 })
-export class Ps1DeleteDialogComponent {
-  readonly game = input.required<Game>();
-  readonly deleteArtwork = input(false);
-  readonly closed = output<void>();
-  readonly logAreaRef = viewChild<ElementRef<HTMLElement>>('logArea');
-
-  entries: DeleteEntry[] = [];
-  deleting = true;
-  overallSuccess = true;
-  private entryIdCounter = 0;
-  private destroyed = false;
-  private readonly _cdr = inject(ChangeDetectorRef);
-  private readonly _destroyRef = inject(DestroyRef);
-
-  constructor(private readonly _libraryService: LibraryService) {
-    this._destroyRef.onDestroy(() => {
-      this.destroyed = true;
-      window.libraryAPI.removeAllDeletePs1ProgressListeners();
-    });
+export class Ps1DeleteDialogComponent extends BaseDeleteDialogComponent {
+  protected validateGame(g: Game): boolean {
+    return !!g.path && !!g.gameId;
   }
 
-  async ngOnInit() {
-    const g = this.game();
-    if (!g || !g.path || !g.gameId) return;
-
-    const handleProgress = (entry: DeleteEntry) => {
-      if (this.destroyed) return;
-      this.entries = [...this.entries, { ...entry, id: ++this.entryIdCounter }];
-      if (!entry.success) this.overallSuccess = false;
-      this._cdr.detectChanges();
-      setTimeout(() => {
-        const el = this.logAreaRef()?.nativeElement;
-        if (el) {
-          el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
-        }
-      });
-    };
-    window.libraryAPI.onDeletePs1Progress(handleProgress);
-
-    try {
-      const currentDir = (this._libraryService.currentDirectoryValue ?? '').replace(/[\\/]/g, '/');
-      const artDir = `${currentDir.replace(/\/$/, '')}/ART`;
-      const result = await window.libraryAPI.deleteGameAndRelatedFiles(
-        g.path,
-        artDir,
-        g.gameId,
-        g.appFolder,
-        this.deleteArtwork() ? g.ps1LauncherBoot : undefined,
-      );
-      if (result) {
-        this.overallSuccess = !!result.success;
-        for (const entry of (result.entries || [])) {
-          const exists = this.entries.some(
-            e => e.label === entry.label && e.path === entry.path
-          );
-          if (!exists) {
-            this.entries = [...this.entries, { ...entry, id: ++this.entryIdCounter }];
-          }
-        }
-      }
-    } catch (err: unknown) {
-      const msg = err instanceof Error ? err.message : String(err);
-      this.entries = [...this.entries, { label: 'Error', success: false, error: msg, id: ++this.entryIdCounter }];
-      this.overallSuccess = false;
-    } finally {
-      window.libraryAPI.removeAllDeletePs1ProgressListeners();
-      this.deleting = false;
-      if (!this.destroyed) this._cdr.detectChanges();
-    }
+  protected registerProgressHandler(
+    handler: (entry: DeleteEntry) => void,
+  ): () => void {
+    window.libraryAPI.onDeletePs1Progress(handler);
+    return () => window.libraryAPI.removeAllDeletePs1ProgressListeners();
   }
 
-  close() {
-    if (this.deleting) return;
-    this.closed.emit();
+  protected async runDeletion(
+    g: Game,
+    currentDir: string,
+    deleteArtwork: boolean,
+  ) {
+    const artDir = `${currentDir.replace(/\/$/, '')}/ART`;
+    return window.libraryAPI.deleteGameAndRelatedFiles(
+      g.path,
+      artDir,
+      g.gameId,
+      g.appFolder,
+      deleteArtwork ? g.ps1LauncherBoot : undefined,
+    );
   }
 }

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
@@ -2,9 +2,11 @@ import {
   ChangeDetectorRef,
   Component,
   DestroyRef,
+  ElementRef,
   inject,
   input,
   output,
+  viewChild,
 } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import { Game } from '@shared/types/game.type';
@@ -27,6 +29,7 @@ interface DeleteEntry {
 export class Ps1DeleteDialogComponent {
   readonly game = input.required<Game>();
   readonly closed = output<void>();
+  readonly logAreaRef = viewChild<ElementRef<HTMLElement>>('logArea');
 
   entries: DeleteEntry[] = [];
   deleting = true;
@@ -35,15 +38,11 @@ export class Ps1DeleteDialogComponent {
   private destroyed = false;
   private readonly _cdr = inject(ChangeDetectorRef);
   private readonly _destroyRef = inject(DestroyRef);
-  private progressCb: ((entry: DeleteEntry) => void) | null = null;
 
   constructor(private readonly _libraryService: LibraryService) {
     this._destroyRef.onDestroy(() => {
       this.destroyed = true;
-      if (this.progressCb) {
-        window.libraryAPI.removeAllDeletePs1ProgressListeners();
-        this.progressCb = null;
-      }
+      window.libraryAPI.removeAllDeletePs1ProgressListeners();
     });
   }
 
@@ -56,14 +55,18 @@ export class Ps1DeleteDialogComponent {
       this.entries = [...this.entries, { ...entry, id: ++this.entryIdCounter }];
       if (!entry.success) this.overallSuccess = false;
       this._cdr.detectChanges();
+      setTimeout(() => {
+        const el = this.logAreaRef()?.nativeElement;
+        if (el) {
+          el.scrollTo({ top: el.scrollHeight, behavior: 'instant' });
+        }
+      });
     };
-    this.progressCb = (entry) => handleProgress(entry);
-    window.libraryAPI.onDeletePs1Progress(this.progressCb);
+    window.libraryAPI.onDeletePs1Progress(handleProgress);
 
     try {
-      const currentDir = this._libraryService.currentDirectoryValue ?? '';
-      const sep = currentDir.includes('\\') ? '\\' : '/';
-      const artDir = `${currentDir.replace(/[\\/]$/, '')}${sep}ART`;
+      const currentDir = (this._libraryService.currentDirectoryValue ?? '').replace(/[\\/]/g, '/');
+      const artDir = `${currentDir.replace(/\/$/, '')}/ART`;
       const result = await window.libraryAPI.deleteGameAndRelatedFiles(
         g.path,
         artDir,
@@ -72,6 +75,14 @@ export class Ps1DeleteDialogComponent {
       );
       if (result) {
         this.overallSuccess = !!result.success;
+        for (const entry of (result.entries || [])) {
+          const exists = this.entries.some(
+            e => e.label === entry.label && e.path === entry.path
+          );
+          if (!exists) {
+            this.entries = [...this.entries, { ...entry, id: ++this.entryIdCounter }];
+          }
+        }
       }
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
@@ -86,7 +97,6 @@ export class Ps1DeleteDialogComponent {
 
   close() {
     if (this.deleting) return;
-    this._libraryService.refreshGamesFiles();
     this.closed.emit();
   }
 }

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
@@ -3,6 +3,13 @@ import { LucideAngularModule } from 'lucide-angular';
 import { Game } from '@shared/types/game.type';
 import { BaseDeleteDialogComponent, DeleteEntry } from '../delete-dialog-base';
 
+/**
+ * Delete-progress dialog for PS1 launcher apps.
+ *
+ * Uses the legacy `deleteGameAndRelatedFiles` IPC channel and listens for
+ * `delete-ps1-progress` events. Artwork deletion is optional and matched
+ * by the boot ELF filename (`ps1LauncherBoot`).
+ */
 @Component({
   selector: 'app-ps1-delete-dialog',
   imports: [LucideAngularModule],
@@ -10,10 +17,12 @@ import { BaseDeleteDialogComponent, DeleteEntry } from '../delete-dialog-base';
   styleUrl: './ps1-delete-dialog.component.scss',
 })
 export class Ps1DeleteDialogComponent extends BaseDeleteDialogComponent {
+  /** Requires `path` (game file) and `gameId` for the legacy API. */
   protected validateGame(g: Game): boolean {
     return !!g.path && !!g.gameId;
   }
 
+  /** Registers a listener for `delete-ps1-progress` IPC events. */
   protected registerProgressHandler(
     handler: (entry: DeleteEntry) => void,
   ): () => void {
@@ -21,6 +30,11 @@ export class Ps1DeleteDialogComponent extends BaseDeleteDialogComponent {
     return () => window.libraryAPI.removeAllDeletePs1ProgressListeners();
   }
 
+  /**
+   * Calls the legacy `deleteGameAndRelatedFiles` which removes the game file,
+   * VCD, launcher folder, POPS subfolder, and optionally artwork matched
+   * by the boot ELF name.
+   */
   protected async runDeletion(
     g: Game,
     currentDir: string,

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
@@ -17,17 +17,17 @@ interface DeleteEntry {
   styleUrl: './ps1-delete-dialog.component.scss',
 })
 export class Ps1DeleteDialogComponent implements OnInit {
-  @Input() game!: Game;
+  @Input({ required: true }) game!: Game;
   @Output() closed = new EventEmitter<void>();
 
   entries: DeleteEntry[] = [];
   deleting = true;
   overallSuccess = false;
 
-  constructor(private readonly _library: LibraryService) {}
+  constructor(private readonly _libraryService: LibraryService) {}
 
   async ngOnInit() {
-    const result = await this._library.deleteGame(this.game, true);
+    const result = await this._libraryService.deleteGame(this.game, true);
     if (result?.entries) {
       this.entries = result.entries;
       this.overallSuccess = !!result.success;
@@ -37,7 +37,7 @@ export class Ps1DeleteDialogComponent implements OnInit {
 
   close() {
     if (this.deleting) return;
-    this._library.refreshGamesFiles();
+    this._libraryService.refreshGamesFiles();
     this.closed.emit();
   }
 }

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
@@ -28,6 +28,7 @@ interface DeleteEntry {
 })
 export class Ps1DeleteDialogComponent {
   readonly game = input.required<Game>();
+  readonly deleteArtwork = input(false);
   readonly closed = output<void>();
   readonly logAreaRef = viewChild<ElementRef<HTMLElement>>('logArea');
 
@@ -72,6 +73,7 @@ export class Ps1DeleteDialogComponent {
         artDir,
         g.gameId,
         g.appFolder,
+        this.deleteArtwork() ? g.ps1LauncherBoot : undefined,
       );
       if (result) {
         this.overallSuccess = !!result.success;

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
@@ -1,4 +1,11 @@
-import { Component, input, output } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  inject,
+  input,
+  output,
+} from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import { Game } from '@shared/types/game.type';
 import { LibraryService } from '@shared/services/library.service';
@@ -8,6 +15,7 @@ interface DeleteEntry {
   path?: string;
   success: boolean;
   error?: string;
+  id?: number;
 }
 
 @Component({
@@ -22,23 +30,57 @@ export class Ps1DeleteDialogComponent {
 
   entries: DeleteEntry[] = [];
   deleting = true;
-  overallSuccess = false;
+  overallSuccess = true;
+  private entryIdCounter = 0;
+  private destroyed = false;
+  private readonly _cdr = inject(ChangeDetectorRef);
+  private readonly _destroyRef = inject(DestroyRef);
+  private progressCb: ((entry: DeleteEntry) => void) | null = null;
 
-  constructor(private readonly _libraryService: LibraryService) {}
+  constructor(private readonly _libraryService: LibraryService) {
+    this._destroyRef.onDestroy(() => {
+      this.destroyed = true;
+      if (this.progressCb) {
+        window.libraryAPI.removeAllDeletePs1ProgressListeners();
+        this.progressCb = null;
+      }
+    });
+  }
 
   async ngOnInit() {
+    const g = this.game();
+    if (!g || !g.path || !g.gameId) return;
+
+    const handleProgress = (entry: DeleteEntry) => {
+      if (this.destroyed) return;
+      this.entries = [...this.entries, { ...entry, id: ++this.entryIdCounter }];
+      if (!entry.success) this.overallSuccess = false;
+      this._cdr.detectChanges();
+    };
+    this.progressCb = (entry) => handleProgress(entry);
+    window.libraryAPI.onDeletePs1Progress(this.progressCb);
+
     try {
-      const result = await this._libraryService.deleteGame(this.game(), true);
-      if (result?.entries) {
-        this.entries = result.entries;
+      const currentDir = this._libraryService.currentDirectoryValue ?? '';
+      const sep = currentDir.includes('\\') ? '\\' : '/';
+      const artDir = `${currentDir.replace(/[\\/]$/, '')}${sep}ART`;
+      const result = await window.libraryAPI.deleteGameAndRelatedFiles(
+        g.path,
+        artDir,
+        g.gameId,
+        g.appFolder,
+      );
+      if (result) {
         this.overallSuccess = !!result.success;
       }
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      this.entries = [{ label: 'Error', success: false, error: msg }];
+      this.entries = [...this.entries, { label: 'Error', success: false, error: msg, id: ++this.entryIdCounter }];
       this.overallSuccess = false;
     } finally {
+      window.libraryAPI.removeAllDeletePs1ProgressListeners();
       this.deleting = false;
+      if (!this.destroyed) this._cdr.detectChanges();
     }
   }
 

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
@@ -1,0 +1,43 @@
+import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { LucideAngularModule } from 'lucide-angular';
+import { Game } from '../../../../shared/types/game.type';
+import { LibraryService } from '../../../../shared/services/library.service';
+
+interface DeleteEntry {
+  label: string;
+  path?: string;
+  success: boolean;
+  error?: string;
+}
+
+@Component({
+  selector: 'app-ps1-delete-dialog',
+  imports: [LucideAngularModule],
+  templateUrl: './ps1-delete-dialog.component.html',
+  styleUrl: './ps1-delete-dialog.component.scss',
+})
+export class Ps1DeleteDialogComponent implements OnInit {
+  @Input() game!: Game;
+  @Output() closed = new EventEmitter<void>();
+
+  entries: DeleteEntry[] = [];
+  deleting = true;
+  overallSuccess = false;
+
+  constructor(private readonly _library: LibraryService) {}
+
+  async ngOnInit() {
+    const result = await this._library.deleteGame(this.game, true);
+    if (result?.entries) {
+      this.entries = result.entries;
+      this.overallSuccess = !!result.success;
+    }
+    this.deleting = false;
+  }
+
+  close() {
+    if (this.deleting) return;
+    this._library.refreshGamesFiles();
+    this.closed.emit();
+  }
+}

--- a/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
+++ b/angular/src/app/pages/library/components/ps1-delete-dialog/ps1-delete-dialog.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
-import { Game } from '../../../../shared/types/game.type';
-import { LibraryService } from '../../../../shared/services/library.service';
+import { Game } from '@shared/types/game.type';
+import { LibraryService } from '@shared/services/library.service';
 
 interface DeleteEntry {
   label: string;

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.html
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.html
@@ -51,9 +51,9 @@
     }
     }
 
-    @if (ps1DialogState === 'running') {
+    @if (ps1DialogState === 'running' || ps1DialogState === 'done') {
     <div #logArea class="log-area rounded-md border border-base-content/10 bg-base-100/30">
-      @for (entry of ps1Log; track entry) {
+      @for (entry of ps1Log; track $index) {
       <div class="log-line" [class.text-info]="entry.type === 'step'" [class.text-warning]="entry.type === 'change'"
         [class.text-success]="entry.type === 'success'" [class.text-error]="entry.type === 'error'"
         [class.font-semibold]="entry.type === 'step'">
@@ -70,33 +70,15 @@
         }
       </div>
       }
-      <div class="log-line log-cursor">
-        <span class="loading loading-dots loading-xs"></span>
-      </div>
+    </div>
+
+    @if (ps1DialogState === 'running') {
+    <div class="log-line log-cursor">
+      <span class="loading loading-dots loading-xs"></span>
     </div>
     }
 
     @if (ps1DialogState === 'done') {
-    <div #logArea class="log-area rounded-md border border-base-content/10 bg-base-100/30">
-      @for (entry of ps1Log; track entry) {
-      <div class="log-line" [class.text-info]="entry.type === 'step'" [class.text-warning]="entry.type === 'change'"
-        [class.text-success]="entry.type === 'success'" [class.text-error]="entry.type === 'error'"
-        [class.font-semibold]="entry.type === 'step'">
-        <span class="log-time">{{ entry.time }}</span>
-        @if (entry.oldText && entry.newText) {
-        <span class="log-text">
-          <span class="opacity-80">{{ entry.text }}</span>
-          <span class="text-error/80">{{ entry.oldText }}</span>
-          <span class="opacity-40"> → </span>
-          <span class="text-success">{{ entry.newText }}</span>
-        </span>
-        } @else {
-        <span class="log-text">{{ entry.text }}</span>
-        }
-      </div>
-      }
-    </div>
-
     <div class="rounded-md border p-3 text-sm" [class.border-success/30]="ps1Log[ps1Log.length - 1]?.type === 'success'"
       [class.bg-success/5]="ps1Log[ps1Log.length - 1]?.type === 'success'"
       [class.border-error/30]="ps1Log[ps1Log.length - 1]?.type === 'error'"
@@ -110,6 +92,7 @@
         </span>
       </div>
     </div>
+    }
     }
 
     <!-- ════════════════════════════════════════════════════════════════

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.html
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.html
@@ -27,8 +27,14 @@
     @if (ps1DialogState === 'input') {
     <fieldset class="fieldset">
       <legend class="fieldset-legend">New name for the PS1 App Game</legend>
-      <input #ps1TitleInput type="text" class="input w-full" [value]="ps1NewTitle"
+      <input #ps1TitleInput type="text" class="input w-full"
+        [class.input-error]="ps1NewTitle.trim() === ''"
+        placeholder="New game title"
+        [value]="ps1NewTitle"
         (input)="onTitleChange(ps1TitleInput.value)" [disabled]="running" />
+      @if (ps1NewTitle.trim() === '') {
+      <p class="mt-1 text-xs text-error">The game name cannot be empty.</p>
+      }
       <p class="flex items-center gap-1.5 text-xs text-base-content/60">
         Renaming
         <span class="font-mono text-base-content/80">POPS/{{ ps1VcdFilename }}</span>

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.html
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.html
@@ -1,33 +1,127 @@
-<div class="rename-backdrop" (click)="close()"></div>
+<div class="rename-backdrop" (click)="ps1CloseAllowed ? close() : null"></div>
 <div class="rename-modal glass-strong" role="dialog">
   <div class="flex items-center gap-2 border-b border-base-content/10 px-5 py-3">
     <i-lucide name="text-cursor-input" size="18" class="text-accent"></i-lucide>
     <h2 class="font-display text-sm font-semibold tracking-wide">
+      @if (isPs1Launcher) {
+      @if (ps1DialogState === 'input') { Rename PS1 App Game }
+      @else if (ps1DialogState === 'running') { Renaming PS1 App Game... }
+      @else { Rename complete }
+      } @else {
       {{ isSingle ? "Rename game to convention" : "Rename all games to convention" }}
+      }
     </h2>
-    <button
-      class="btn btn-ghost btn-xs btn-square ml-auto"
-      (click)="close()"
-      [disabled]="running"
-    >
+    <button class="btn btn-ghost btn-xs btn-square ml-auto" (click)="close()"
+      [disabled]="running || (isPs1Launcher && ps1DialogState !== 'input')">
       <i-lucide name="x" size="16"></i-lucide>
     </button>
   </div>
 
   <div class="rename-body flex flex-col gap-4 px-5 py-4">
     @if (!done) {
+
+    <!-- ════════════════════════════════════════════════════════════════
+         PS1 LAUNCHER FLOW
+         ════════════════════════════════════════════════════════════════ -->
+    @if (isPs1Launcher) {
+
+    @if (ps1DialogState === 'input') {
+    <fieldset class="fieldset">
+      <legend class="fieldset-legend">New name for the PS1 App Game</legend>
+      <input #ps1TitleInput type="text" class="input w-full" [value]="ps1NewTitle"
+        (input)="onTitleChange(ps1TitleInput.value)" [disabled]="running" />
+      <p class="flex items-center gap-1.5 text-xs text-base-content/60">
+        Renaming
+        <span class="font-mono text-base-content/80">POPS/{{ ps1VcdFilename }}</span>
+      </p>
+    </fieldset>
+
+    @if (ps1Preview && hasChanges) {
+    <div class="rounded-md border border-warning/30 bg-warning/5 p-3 text-xs leading-relaxed">
+      <span class="mb-1 flex items-center gap-1.5 text-sm font-semibold text-warning">
+        <i-lucide name="triangle-alert" size="15"></i-lucide>
+        The following changes will be applied
+      </span>
+      <ul class="ml-1 list-inside list-disc space-y-1 text-base-content/75">
+        <li><span class="font-mono">{{ ps1Preview.vcd }}</span></li>
+        <li><span class="font-mono">{{ ps1Preview.popsFolder }}</span></li>
+        <li><span class="font-mono">{{ ps1Preview.appsFolder }}</span></li>
+      </ul>
+    </div>
+    }
+    }
+
+    @if (ps1DialogState === 'running') {
+    <div #logArea class="log-area rounded-md border border-base-content/10 bg-base-100/30">
+      @for (entry of ps1Log; track entry) {
+      <div class="log-line" [class.text-info]="entry.type === 'step'" [class.text-warning]="entry.type === 'change'"
+        [class.text-success]="entry.type === 'success'" [class.text-error]="entry.type === 'error'"
+        [class.font-semibold]="entry.type === 'step'">
+        <span class="log-time">{{ entry.time }}</span>
+        @if (entry.oldText && entry.newText) {
+        <span class="log-text">
+          <span class="opacity-80">{{ entry.text }}</span>
+          <span class="text-error/80">{{ entry.oldText }}</span>
+          <span class="opacity-40"> → </span>
+          <span class="text-success">{{ entry.newText }}</span>
+        </span>
+        } @else {
+        <span class="log-text">{{ entry.text }}</span>
+        }
+      </div>
+      }
+      <div class="log-line log-cursor">
+        <span class="loading loading-dots loading-xs"></span>
+      </div>
+    </div>
+    }
+
+    @if (ps1DialogState === 'done') {
+    <div #logArea class="log-area rounded-md border border-base-content/10 bg-base-100/30">
+      @for (entry of ps1Log; track entry) {
+      <div class="log-line" [class.text-info]="entry.type === 'step'" [class.text-warning]="entry.type === 'change'"
+        [class.text-success]="entry.type === 'success'" [class.text-error]="entry.type === 'error'"
+        [class.font-semibold]="entry.type === 'step'">
+        <span class="log-time">{{ entry.time }}</span>
+        @if (entry.oldText && entry.newText) {
+        <span class="log-text">
+          <span class="opacity-80">{{ entry.text }}</span>
+          <span class="text-error/80">{{ entry.oldText }}</span>
+          <span class="opacity-40"> → </span>
+          <span class="text-success">{{ entry.newText }}</span>
+        </span>
+        } @else {
+        <span class="log-text">{{ entry.text }}</span>
+        }
+      </div>
+      }
+    </div>
+
+    <div class="rounded-md border p-3 text-sm" [class.border-success/30]="ps1Log[ps1Log.length - 1]?.type === 'success'"
+      [class.bg-success/5]="ps1Log[ps1Log.length - 1]?.type === 'success'"
+      [class.border-error/30]="ps1Log[ps1Log.length - 1]?.type === 'error'"
+      [class.bg-error/5]="ps1Log[ps1Log.length - 1]?.type === 'error'">
+      <div class="flex items-center gap-2">
+        <i-lucide [name]="ps1Log[ps1Log.length - 1]?.type === 'error' ? 'triangle-alert' : 'circle-check'" size="18"
+          [class.text-success]="ps1Log[ps1Log.length - 1]?.type !== 'error'"
+          [class.text-error]="ps1Log[ps1Log.length - 1]?.type === 'error'"></i-lucide>
+        <span class="font-semibold">
+          {{ ps1Log[ps1Log.length - 1]?.type === 'error' ? 'Failed' : 'Done' }}
+        </span>
+      </div>
+    </div>
+    }
+
+    <!-- ════════════════════════════════════════════════════════════════
+         PS2 DISK IMAGE FLOW (unchanged)
+         ════════════════════════════════════════════════════════════════ -->
+    } @else {
     <div>
       <span class="text-sm font-semibold">Target convention</span>
       <div class="mt-2 flex flex-col gap-2">
         <label class="flex cursor-pointer items-start gap-2 rounded-md p-2 hover:bg-base-100/40">
-          <input
-            type="radio"
-            name="convention"
-            class="radio radio-primary radio-sm mt-0.5"
-            [checked]="convention === 'new'"
-            [disabled]="running"
-            (change)="setConvention('new')"
-          />
+          <input type="radio" name="convention" class="radio radio-primary radio-sm mt-0.5"
+            [checked]="convention === 'new'" [disabled]="running" (change)="setConvention('new')" />
           <span class="leading-tight">
             <span class="text-sm">New — &lt;Title&gt;.iso</span>
             <span class="block text-[0.68rem] text-base-content/55">
@@ -37,14 +131,8 @@
           </span>
         </label>
         <label class="flex cursor-pointer items-start gap-2 rounded-md p-2 hover:bg-base-100/40">
-          <input
-            type="radio"
-            name="convention"
-            class="radio radio-primary radio-sm mt-0.5"
-            [checked]="convention === 'old'"
-            [disabled]="running"
-            (change)="setConvention('old')"
-          />
+          <input type="radio" name="convention" class="radio radio-primary radio-sm mt-0.5"
+            [checked]="convention === 'old'" [disabled]="running" (change)="setConvention('old')" />
           <span class="leading-tight">
             <span class="text-sm">Old — &lt;GAMEID&gt;.&lt;Title&gt;.iso</span>
             <span class="block text-[0.68rem] text-base-content/55">
@@ -77,25 +165,18 @@
 
     @if (running) {
     <div>
-      <progress
-        class="progress progress-primary h-2 w-full"
-        [value]="progress"
-        max="100"
-      ></progress>
+      <progress class="progress progress-primary h-2 w-full" [value]="progress" max="100"></progress>
       <p class="mt-1 truncate text-[0.68rem] text-base-content/55">
         {{ currentLabel }}
       </p>
     </div>
     }
+    }
     } @else {
     <div class="rounded-md border border-base-content/10 bg-base-100/30 p-4 text-sm">
       <div class="flex items-center gap-2">
-        <i-lucide
-          [name]="failed === 0 ? 'circle-check' : 'triangle-alert'"
-          size="18"
-          [class.text-success]="failed === 0"
-          [class.text-warning]="failed > 0"
-        ></i-lucide>
+        <i-lucide [name]="failed === 0 ? 'circle-check' : 'triangle-alert'" size="18"
+          [class.text-success]="failed === 0" [class.text-warning]="failed > 0"></i-lucide>
         <span class="font-semibold">Done.</span>
       </div>
       <p class="mt-1 text-sm text-base-content/70">
@@ -109,15 +190,26 @@
   </div>
 
   <div class="flex justify-end gap-2 border-t border-base-content/10 px-5 py-3">
+    @if (isPs1Launcher) {
+    @if (ps1DialogState === 'input') {
+    <button class="btn btn-ghost btn-sm" (click)="close()" [disabled]="running">
+      Cancel
+    </button>
+    <button class="btn btn-primary btn-sm" (click)="run()" [disabled]="!hasChanges">
+      <i-lucide name="text-cursor-input" size="15"></i-lucide>
+      Rename game
+    </button>
+    } @else if (ps1DialogState === 'running') {
+    <span class="text-xs text-base-content/40">Renaming — do not close...</span>
+    } @else {
+    <button class="btn btn-primary btn-sm" (click)="close()">Close</button>
+    }
+    } @else {
     @if (!done) {
     <button class="btn btn-ghost btn-sm" (click)="close()" [disabled]="running">
       Cancel
     </button>
-    <button
-      class="btn btn-primary btn-sm"
-      (click)="run()"
-      [disabled]="running || planCount === 0"
-    >
+    <button class="btn btn-primary btn-sm" (click)="run()" [disabled]="running || planCount === 0">
       @if (running) {
       <span class="loading loading-spinner loading-xs"></span>
       } @else {
@@ -127,6 +219,7 @@
     </button>
     } @else {
     <button class="btn btn-primary btn-sm" (click)="close()">Close</button>
+    }
     }
   </div>
 </div>

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.html
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.html
@@ -79,16 +79,14 @@
     }
 
     @if (ps1DialogState === 'done') {
-    <div class="rounded-md border p-3 text-sm" [class.border-success/30]="ps1Log[ps1Log.length - 1]?.type === 'success'"
-      [class.bg-success/5]="ps1Log[ps1Log.length - 1]?.type === 'success'"
-      [class.border-error/30]="ps1Log[ps1Log.length - 1]?.type === 'error'"
-      [class.bg-error/5]="ps1Log[ps1Log.length - 1]?.type === 'error'">
+    <div class="rounded-md border p-3 text-sm" [class.border-success/30]="lastLogType === 'success'"
+      [class.bg-success/5]="lastLogType === 'success'" [class.border-error/30]="lastLogType === 'error'"
+      [class.bg-error/5]="lastLogType === 'error'">
       <div class="flex items-center gap-2">
-        <i-lucide [name]="ps1Log[ps1Log.length - 1]?.type === 'error' ? 'triangle-alert' : 'circle-check'" size="18"
-          [class.text-success]="ps1Log[ps1Log.length - 1]?.type !== 'error'"
-          [class.text-error]="ps1Log[ps1Log.length - 1]?.type === 'error'"></i-lucide>
+        <i-lucide [name]="lastLogType === 'error' ? 'triangle-alert' : 'circle-check'" size="18"
+          [class.text-success]="lastLogType !== 'error'" [class.text-error]="lastLogType === 'error'"></i-lucide>
         <span class="font-semibold">
-          {{ ps1Log[ps1Log.length - 1]?.type === 'error' ? 'Failed' : 'Done' }}
+          {{ lastLogType === 'error' ? 'Failed' : 'Done' }}
         </span>
       </div>
     </div>

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.html
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.html
@@ -11,10 +11,6 @@
       {{ isSingle ? "Rename game to convention" : "Rename all games to convention" }}
       }
     </h2>
-    <button class="btn btn-ghost btn-xs btn-square ml-auto" (click)="close()"
-      [disabled]="running || (isPs1Launcher && ps1DialogState !== 'input')">
-      <i-lucide name="x" size="16"></i-lucide>
-    </button>
   </div>
 
   <div class="rename-body flex flex-col gap-4 px-5 py-4">
@@ -53,7 +49,7 @@
 
     @if (ps1DialogState === 'running' || ps1DialogState === 'done') {
     <div #logArea class="log-area rounded-md border border-base-content/10 bg-base-100/30">
-      @for (entry of ps1Log; track $index) {
+      @for (entry of ps1Log; track entry) {
       <div class="log-line" [class.text-info]="entry.type === 'step'" [class.text-warning]="entry.type === 'change'"
         [class.text-success]="entry.type === 'success'" [class.text-error]="entry.type === 'error'"
         [class.font-semibold]="entry.type === 'step'">
@@ -72,13 +68,6 @@
       }
     </div>
 
-    @if (ps1DialogState === 'running') {
-    <div class="log-line log-cursor">
-      <span class="loading loading-dots loading-xs"></span>
-    </div>
-    }
-
-    @if (ps1DialogState === 'done') {
     <div class="rounded-md border p-3 text-sm" [class.border-success/30]="lastLogType === 'success'"
       [class.bg-success/5]="lastLogType === 'success'" [class.border-error/30]="lastLogType === 'error'"
       [class.bg-error/5]="lastLogType === 'error'">
@@ -90,7 +79,6 @@
         </span>
       </div>
     </div>
-    }
     }
 
     <!-- ════════════════════════════════════════════════════════════════
@@ -180,10 +168,9 @@
       <i-lucide name="text-cursor-input" size="15"></i-lucide>
       Rename game
     </button>
-    } @else if (ps1DialogState === 'running') {
-    <span class="text-xs text-base-content/40">Renaming — do not close...</span>
-    } @else {
-    <button class="btn btn-primary btn-sm" (click)="close()">Close</button>
+    }
+    @else {
+    <button class="btn btn-primary btn-sm" (click)="close()" [disabled]="running">Close</button>
     }
     } @else {
     @if (!done) {

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.html
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.html
@@ -11,6 +11,9 @@
       {{ isSingle ? "Rename game to convention" : "Rename all games to convention" }}
       }
     </h2>
+    <button class="btn btn-ghost btn-xs btn-square ml-auto" (click)="close()" [disabled]="running">
+      <i-lucide name="x" size="16"></i-lucide>
+    </button>
   </div>
 
   <div class="rename-body flex flex-col gap-4 px-5 py-4">
@@ -49,7 +52,7 @@
 
     @if (ps1DialogState === 'running' || ps1DialogState === 'done') {
     <div #logArea class="log-area rounded-md border border-base-content/10 bg-base-100/30">
-      @for (entry of ps1Log; track entry) {
+      @for (entry of ps1Log; track entry.id) {
       <div class="log-line" [class.text-info]="entry.type === 'step'" [class.text-warning]="entry.type === 'change'"
         [class.text-success]="entry.type === 'success'" [class.text-error]="entry.type === 'error'"
         [class.font-semibold]="entry.type === 'step'">
@@ -68,6 +71,7 @@
       }
     </div>
 
+    @if (ps1DialogState === 'done') {
     <div class="rounded-md border p-3 text-sm" [class.border-success/30]="lastLogType === 'success'"
       [class.bg-success/5]="lastLogType === 'success'" [class.border-error/30]="lastLogType === 'error'"
       [class.bg-error/5]="lastLogType === 'error'">
@@ -79,6 +83,7 @@
         </span>
       </div>
     </div>
+    }
     }
 
     <!-- ════════════════════════════════════════════════════════════════

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.scss
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.scss
@@ -6,7 +6,7 @@
   position: fixed;
   inset: 0;
   z-index: 50;
-  background: rgba(0, 0, 0, 0.55);
+  background: oklch(0% 0 0 / 0.55);
   backdrop-filter: blur(2px);
 }
 
@@ -21,7 +21,7 @@
   display: flex;
   flex-direction: column;
   border-radius: 1rem;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  box-shadow: 0 20px 60px oklch(0% 0 0 / 0.5);
   overflow: hidden;
 }
 
@@ -34,7 +34,7 @@
   overflow-y: auto;
   max-height: 18rem;
   padding: 0.5rem;
-  font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  font-family: "Cascadia Code", "Fira Code", "Consolas", monospace;
   font-size: 0.7rem;
   line-height: 1.6;
 }

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.scss
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.scss
@@ -27,4 +27,38 @@
 
 .rename-body {
   overflow-y: auto;
+  overflow-wrap: break-word;
+}
+
+.log-area {
+  overflow-y: auto;
+  max-height: 18rem;
+  padding: 0.5rem;
+  font-family: 'Cascadia Code', 'Fira Code', 'Consolas', monospace;
+  font-size: 0.7rem;
+  line-height: 1.6;
+}
+
+.log-line {
+  display: flex;
+}
+
+.log-time {
+  flex-shrink: 0;
+  width: 4.2rem;
+  opacity: 0.35;
+  user-select: none;
+}
+
+.log-text {
+  overflow-wrap: break-word;
+  min-width: 0;
+}
+
+.log-cursor {
+  opacity: 0.5;
+}
+
+.rename-body .font-mono {
+  overflow-wrap: break-word;
 }

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
@@ -1,4 +1,13 @@
-import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
+import {
+  Component,
+  ElementRef,
+  EventEmitter,
+  Input,
+  OnDestroy,
+  OnInit,
+  Output,
+  ViewChild,
+} from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import { LibraryService } from '../../../../shared/services/library.service';
 import { JobsService } from '../../../../shared/services/jobs.service';
@@ -32,7 +41,7 @@ interface LogEntry {
   templateUrl: './rename-dialog.component.html',
   styleUrl: './rename-dialog.component.scss',
 })
-export class LibraryRenameDialogComponent implements OnInit {
+export class LibraryRenameDialogComponent implements OnInit, OnDestroy {
   @Input() game?: Game;
   @Output() closed = new EventEmitter<void>();
   @ViewChild('logArea') logAreaRef?: ElementRef<HTMLElement>;
@@ -54,10 +63,12 @@ export class LibraryRenameDialogComponent implements OnInit {
 
   private plan: RenamePlanItem[] = [];
   private candidates: Game[] = [];
+  private destroyed = false;
+  private progressCb: ((progress: any) => void) | null = null;
 
   constructor(
     private readonly _library: LibraryService,
-    private readonly _jobs: JobsService
+    private readonly _jobs: JobsService,
   ) {}
 
   private isEligible(g: Game): boolean {
@@ -100,6 +111,20 @@ export class LibraryRenameDialogComponent implements OnInit {
     const g = this.game;
     if (!g || !g.isPs1Launcher) return '';
     return g.filename;
+  }
+
+  get lastLogType(): LogEntry['type'] | null {
+    return this.ps1Log.length > 0
+      ? this.ps1Log[this.ps1Log.length - 1].type
+      : null;
+  }
+
+  ngOnDestroy() {
+    this.destroyed = true;
+    if (this.progressCb) {
+      window.libraryAPI.removeAllRenamePs1ProgressListeners();
+      this.progressCb = null;
+    }
   }
 
   ngOnInit() {
@@ -183,7 +208,12 @@ export class LibraryRenameDialogComponent implements OnInit {
     }
   }
 
-  private addLog(text: string, type: LogEntry['type'] = 'info', oldText?: string, newText?: string) {
+  private addLog(
+    text: string,
+    type: LogEntry['type'] = 'info',
+    oldText?: string,
+    newText?: string,
+  ) {
     const now = new Date();
     const time = now.toLocaleTimeString('en-US', { hour12: false });
     if (oldText !== undefined && newText !== undefined) {
@@ -192,7 +222,10 @@ export class LibraryRenameDialogComponent implements OnInit {
       this.ps1Log = [...this.ps1Log, { time, text, type }];
     }
     requestAnimationFrame(() => {
-      this.logAreaRef?.nativeElement.scrollTo({ top: this.logAreaRef.nativeElement.scrollHeight, behavior: 'instant' });
+      this.logAreaRef?.nativeElement.scrollTo({
+        top: this.logAreaRef.nativeElement.scrollHeight,
+        behavior: 'instant',
+      });
     });
   }
 
@@ -213,7 +246,8 @@ export class LibraryRenameDialogComponent implements OnInit {
     if (!g || !g.isPs1Launcher || !g.path || !g.gameId) return;
 
     const newTitle = this.sanitize(this.ps1NewTitle || '');
-    if (!newTitle || this.ps1NewTitle.trim() === this.initialPs1NewTitle) return;
+    if (!newTitle || this.ps1NewTitle.trim() === this.initialPs1NewTitle)
+      return;
 
     this.running = true;
     this.ps1DialogState = 'running';
@@ -221,12 +255,14 @@ export class LibraryRenameDialogComponent implements OnInit {
 
     this.addLog(`Renaming "${g.title}" → "${newTitle}"`, 'step');
 
-    window.libraryAPI.onRenamePs1Progress((progress) => {
-      const isChange = progress.stage.startsWith('Renaming VCD:')
-        || progress.stage.startsWith('Renaming VMC')
-        || progress.stage.startsWith('Renaming APPS folder')
-        || progress.stage.startsWith('Renaming ELF:')
-        || progress.stage.startsWith('Updating title.cfg');
+    this.progressCb = (progress) => {
+      if (this.destroyed) return;
+      const isChange =
+        progress.stage.startsWith('Renaming VCD:') ||
+        progress.stage.startsWith('Renaming VMC') ||
+        progress.stage.startsWith('Renaming APPS folder') ||
+        progress.stage.startsWith('Renaming ELF:') ||
+        progress.stage.startsWith('Updating title.cfg');
       if (isChange) {
         const p = this.parseChangeMsg(progress.stage);
         if (p) {
@@ -237,12 +273,15 @@ export class LibraryRenameDialogComponent implements OnInit {
       } else {
         this.addLog(progress.stage, 'info');
       }
-    });
+    };
+    window.libraryAPI.onRenamePs1Progress(this.progressCb);
 
     try {
       this.addLog('Step 1 — Renaming folders', 'step');
       const step1 = await window.libraryAPI.renamePs1LauncherStep1(
-        g.path, g.gameId, newTitle
+        g.path,
+        g.gameId,
+        newTitle,
       );
 
       if (!step1.success) {
@@ -253,13 +292,24 @@ export class LibraryRenameDialogComponent implements OnInit {
       }
       this.addLog('Folders renamed', 'success');
 
-      if (step1.oldElfFile && step1.newElfFile && step1.oldElfFile !== step1.newElfFile) {
+      if (
+        step1.oldElfFile &&
+        step1.newElfFile &&
+        step1.oldElfFile !== step1.newElfFile
+      ) {
         this.addLog('ELF: ', 'change', step1.oldElfFile, step1.newElfFile);
+      }
+
+      if (!step1.newAppsFolder) {
+        this.addLog('Internal error: newAppsFolder missing', 'error');
+        this.ps1DialogState = 'done';
+        this.running = false;
+        return;
       }
 
       this.addLog('Step 2 — Updating APPS contents (ELF, title.cfg)', 'step');
       const step2 = await window.libraryAPI.renamePs1LauncherStep2({
-        newAppsFolder: step1.newAppsFolder!,
+        newAppsFolder: step1.newAppsFolder,
         oldElfFile: step1.oldElfFile,
         newElfFile: step1.newElfFile,
         newCfgContent: step1.newCfgContent,
@@ -302,7 +352,7 @@ export class LibraryRenameDialogComponent implements OnInit {
         gameName: game.title || game.gameId,
         downloadArtwork: false,
         keepOriginalName: this.convention === 'new',
-      }))
+      })),
     );
     this.close();
   }

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
@@ -191,8 +191,8 @@ export class LibraryRenameDialogComponent implements OnInit {
     } else {
       this.ps1Log = [...this.ps1Log, { time, text, type }];
     }
-    setTimeout(() => {
-      this.logAreaRef?.nativeElement.scrollTo({ top: this.logAreaRef.nativeElement.scrollHeight, behavior: 'smooth' });
+    requestAnimationFrame(() => {
+      this.logAreaRef?.nativeElement.scrollTo({ top: this.logAreaRef.nativeElement.scrollHeight, behavior: 'instant' });
     });
   }
 

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
@@ -1,12 +1,11 @@
 import {
   Component,
+  DestroyRef,
   ElementRef,
-  EventEmitter,
-  Input,
-  OnDestroy,
-  OnInit,
-  Output,
-  ViewChild,
+  inject,
+  input,
+  output,
+  viewChild,
 } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import { LibraryService } from '@shared/services/library.service';
@@ -27,6 +26,10 @@ interface Ps1RenamePreview {
   appsFolder: string;
 }
 
+interface Ps1RenameProgress {
+  stage: string;
+}
+
 interface LogEntry {
   time: string;
   text: string;
@@ -41,10 +44,10 @@ interface LogEntry {
   templateUrl: './rename-dialog.component.html',
   styleUrl: './rename-dialog.component.scss',
 })
-export class LibraryRenameDialogComponent implements OnInit, OnDestroy {
-  @Input() game?: Game;
-  @Output() closed = new EventEmitter<void>();
-  @ViewChild('logArea') logAreaRef?: ElementRef<HTMLElement>;
+export class LibraryRenameDialogComponent {
+  readonly game = input<Game>();
+  readonly closed = output<void>();
+  readonly logAreaRef = viewChild<ElementRef<HTMLElement>>('logArea');
 
   convention: Convention = 'new';
   running = false;
@@ -64,10 +67,11 @@ export class LibraryRenameDialogComponent implements OnInit, OnDestroy {
   private plan: RenamePlanItem[] = [];
   private candidates: Game[] = [];
   private destroyed = false;
-  private progressCb: ((progress: any) => void) | null = null;
+  private readonly _destroyRef = inject(DestroyRef);
+  private progressCb: ((progress: Ps1RenameProgress) => void) | null = null;
 
   constructor(
-    private readonly _library: LibraryService,
+    private readonly _libraryService: LibraryService,
     private readonly _jobs: JobsService,
   ) {}
 
@@ -85,11 +89,11 @@ export class LibraryRenameDialogComponent implements OnInit, OnDestroy {
   }
 
   get isSingle(): boolean {
-    return !!this.game;
+    return !!this.game();
   }
 
   get isPs1Launcher(): boolean {
-    return !!this.game?.isPs1Launcher;
+    return !!this.game()?.isPs1Launcher;
   }
 
   get hasChanges(): boolean {
@@ -108,7 +112,7 @@ export class LibraryRenameDialogComponent implements OnInit, OnDestroy {
   }
 
   get ps1VcdFilename(): string {
-    const g = this.game;
+    const g = this.game();
     if (!g || !g.isPs1Launcher) return '';
     return g.filename;
   }
@@ -119,27 +123,28 @@ export class LibraryRenameDialogComponent implements OnInit, OnDestroy {
       : null;
   }
 
-  ngOnDestroy() {
-    this.destroyed = true;
-    if (this.progressCb) {
-      window.libraryAPI.removeAllRenamePs1ProgressListeners();
-      this.progressCb = null;
-    }
-  }
-
   ngOnInit() {
-    const pool = this.game ? [this.game] : this._library.currentLibraryValue;
+    const g = this.game();
+    const pool = g ? [g] : this._libraryService.currentLibraryValue;
     this.candidates = pool.filter((g) => this.isEligible(g));
-    if (this.isPs1Launcher && this.game) {
-      const ext = this.game.extension || '.VCD';
-      this.ps1NewTitle = this.game.filename.endsWith(ext)
-        ? this.game.filename.slice(0, -ext.length)
-        : this.game.filename;
+    if (this.isPs1Launcher && g) {
+      const ext = g.extension || '.VCD';
+      this.ps1NewTitle = g.filename.endsWith(ext)
+        ? g.filename.slice(0, -ext.length)
+        : g.filename;
       this.initialPs1NewTitle = this.ps1NewTitle;
       this.buildPs1Preview();
     } else {
       this.rebuildPlan();
     }
+
+    this._destroyRef.onDestroy(() => {
+      this.destroyed = true;
+      if (this.progressCb) {
+        window.libraryAPI.removeAllRenamePs1ProgressListeners();
+        this.progressCb = null;
+      }
+    });
   }
 
   setConvention(c: Convention) {
@@ -168,7 +173,7 @@ export class LibraryRenameDialogComponent implements OnInit, OnDestroy {
   }
 
   private buildPs1Preview() {
-    const g = this.game;
+    const g = this.game();
     if (!g || !g.isPs1Launcher) return;
 
     const oldTitle = g.title || '';
@@ -222,8 +227,8 @@ export class LibraryRenameDialogComponent implements OnInit, OnDestroy {
       this.ps1Log = [...this.ps1Log, { time, text, type }];
     }
     requestAnimationFrame(() => {
-      this.logAreaRef?.nativeElement.scrollTo({
-        top: this.logAreaRef.nativeElement.scrollHeight,
+      this.logAreaRef()?.nativeElement.scrollTo({
+        top: this.logAreaRef()?.nativeElement.scrollHeight ?? 0,
         behavior: 'instant',
       });
     });
@@ -242,7 +247,7 @@ export class LibraryRenameDialogComponent implements OnInit, OnDestroy {
   }
 
   private async runPs1() {
-    const g = this.game;
+    const g = this.game();
     if (!g || !g.isPs1Launcher || !g.path || !g.gameId) return;
 
     const newTitle = this.sanitize(this.ps1NewTitle || '');
@@ -325,8 +330,9 @@ export class LibraryRenameDialogComponent implements OnInit, OnDestroy {
 
       this.ps1DialogState = 'done';
       this.running = false;
-    } catch (err: any) {
-      this.addLog(`Error: ${err?.message || err}`, 'error');
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.addLog(`Error: ${msg}`, 'error');
       this.ps1DialogState = 'done';
       this.running = false;
     } finally {
@@ -337,7 +343,7 @@ export class LibraryRenameDialogComponent implements OnInit, OnDestroy {
   run() {
     if (this.running) return;
 
-    if (this.isPs1Launcher && this.game) {
+    if (this.isPs1Launcher && this.game()) {
       void this.runPs1();
       return;
     }

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
@@ -9,9 +9,9 @@ import {
   ViewChild,
 } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
-import { LibraryService } from '../../../../shared/services/library.service';
-import { JobsService } from '../../../../shared/services/jobs.service';
-import { Game } from '../../../../shared/types/game.type';
+import { LibraryService } from '@shared/services/library.service';
+import { JobsService } from '@shared/services/jobs.service';
+import { Game } from '@shared/types/game.type';
 
 type Convention = 'old' | 'new';
 

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
@@ -1,4 +1,4 @@
-import { Component, EventEmitter, Input, OnInit, Output } from '@angular/core';
+import { Component, ElementRef, EventEmitter, Input, OnInit, Output, ViewChild } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import { LibraryService } from '../../../../shared/services/library.service';
 import { JobsService } from '../../../../shared/services/jobs.service';
@@ -12,6 +12,20 @@ interface RenamePlanItem {
   target: string;
 }
 
+interface Ps1RenamePreview {
+  vcd: string;
+  popsFolder: string;
+  appsFolder: string;
+}
+
+interface LogEntry {
+  time: string;
+  text: string;
+  type: 'info' | 'success' | 'error' | 'step' | 'change';
+  oldText?: string;
+  newText?: string;
+}
+
 @Component({
   selector: 'app-library-rename-dialog',
   imports: [LucideAngularModule],
@@ -19,10 +33,9 @@ interface RenamePlanItem {
   styleUrl: './rename-dialog.component.scss',
 })
 export class LibraryRenameDialogComponent implements OnInit {
-  /** When provided, the dialog operates on this single game instead of the
-   *  whole library. */
   @Input() game?: Game;
   @Output() closed = new EventEmitter<void>();
+  @ViewChild('logArea') logAreaRef?: ElementRef<HTMLElement>;
 
   convention: Convention = 'new';
   running = false;
@@ -32,10 +45,14 @@ export class LibraryRenameDialogComponent implements OnInit {
   progress = 0;
   currentLabel = '';
 
-  /** Pre-computed plan: only entries whose filename would actually change. */
-  private plan: RenamePlanItem[] = [];
+  ps1NewTitle = '';
+  ps1Preview: Ps1RenamePreview | null = null;
+  private initialPs1NewTitle = '';
 
-  /** Same in both modes — eligible PS2 disc images on disk. */
+  ps1DialogState: 'input' | 'running' | 'done' = 'input';
+  ps1Log: LogEntry[] = [];
+
+  private plan: RenamePlanItem[] = [];
   private candidates: Game[] = [];
 
   constructor(
@@ -43,8 +60,10 @@ export class LibraryRenameDialogComponent implements OnInit {
     private readonly _jobs: JobsService
   ) {}
 
-  /** Per-game eligibility check shared by both bulk and single modes. */
   private isEligible(g: Game): boolean {
+    if (g.isPs1Launcher) {
+      return !!g.path && !!g.gameId && !!g.title;
+    }
     return (
       (g.system ?? 'PS2') === 'PS2' &&
       (g.format === 'ISO' || g.format === 'ZSO') &&
@@ -58,15 +77,54 @@ export class LibraryRenameDialogComponent implements OnInit {
     return !!this.game;
   }
 
+  get isPs1Launcher(): boolean {
+    return !!this.game?.isPs1Launcher;
+  }
+
+  get hasChanges(): boolean {
+    if (this.isPs1Launcher) {
+      return (
+        !!this.ps1NewTitle &&
+        this.ps1NewTitle.trim() !== '' &&
+        this.ps1NewTitle.trim() !== this.initialPs1NewTitle
+      );
+    }
+    return this.plan.length > 0;
+  }
+
+  get ps1CloseAllowed(): boolean {
+    return !this.isPs1Launcher || this.ps1DialogState === 'input';
+  }
+
+  get ps1VcdFilename(): string {
+    const g = this.game;
+    if (!g || !g.isPs1Launcher) return '';
+    return g.filename;
+  }
+
   ngOnInit() {
     const pool = this.game ? [this.game] : this._library.currentLibraryValue;
     this.candidates = pool.filter((g) => this.isEligible(g));
-    this.rebuildPlan();
+    if (this.isPs1Launcher && this.game) {
+      const ext = this.game.extension || '.VCD';
+      this.ps1NewTitle = this.game.filename.endsWith(ext)
+        ? this.game.filename.slice(0, -ext.length)
+        : this.game.filename;
+      this.initialPs1NewTitle = this.ps1NewTitle;
+      this.buildPs1Preview();
+    } else {
+      this.rebuildPlan();
+    }
   }
 
   setConvention(c: Convention) {
     this.convention = c;
     this.rebuildPlan();
+  }
+
+  onTitleChange(value: string) {
+    this.ps1NewTitle = value;
+    this.buildPs1Preview();
   }
 
   get planCount(): number {
@@ -78,33 +136,163 @@ export class LibraryRenameDialogComponent implements OnInit {
   }
 
   private sanitize(name: string): string {
-    // Mirrors sanitizeGameFilename on the main side.
     return name
       .replace(/[\\/:*?"<>|]/g, '')
       .replace(/\s+/g, ' ')
       .trim();
   }
 
+  private buildPs1Preview() {
+    const g = this.game;
+    if (!g || !g.isPs1Launcher) return;
+
+    const oldTitle = g.title || '';
+    const newTitle = this.sanitize(this.ps1NewTitle || '') || '(invalid)';
+    const ext = g.extension || '.VCD';
+
+    const oldVcd = g.filename;
+    const newVcd = `${newTitle}${ext}`;
+
+    const oldAppsFolder = `POPS_${oldTitle}`;
+    const newAppsFolder = `POPS_${newTitle}`;
+
+    const oldPopsFolder = oldTitle;
+    const newPopsFolder = newTitle;
+
+    this.ps1Preview = {
+      vcd: `POPS/${oldVcd} → POPS/${newVcd}`,
+      popsFolder: `POPS/${oldPopsFolder}/ → POPS/${newPopsFolder}/`,
+      appsFolder: `APPS/${oldAppsFolder}/ → APPS/${newAppsFolder}/`,
+    };
+  }
+
   private rebuildPlan() {
     this.plan = [];
     for (const game of this.candidates) {
-      const ext = game.extension; // includes leading dot
+      if (game.isPs1Launcher) continue;
+      const ext = game.extension;
       const safeTitle = this.sanitize(game.title || game.gameId);
       const target =
         this.convention === 'new'
           ? `${safeTitle}${ext}`
           : `${game.gameId}.${safeTitle}${ext}`;
-      const current = `${game.filename}`; // already includes extension
+      const current = `${game.filename}`;
       if (current !== target) {
         this.plan.push({ game, current, target });
       }
     }
   }
 
+  private addLog(text: string, type: LogEntry['type'] = 'info', oldText?: string, newText?: string) {
+    const now = new Date();
+    const time = now.toLocaleTimeString('en-US', { hour12: false });
+    if (oldText !== undefined && newText !== undefined) {
+      this.ps1Log = [...this.ps1Log, { time, text, type, oldText, newText }];
+    } else {
+      this.ps1Log = [...this.ps1Log, { time, text, type }];
+    }
+    setTimeout(() => {
+      this.logAreaRef?.nativeElement.scrollTo({ top: this.logAreaRef.nativeElement.scrollHeight, behavior: 'smooth' });
+    });
+  }
+
+  private parseChangeMsg(full: string) {
+    const arrowIdx = full.indexOf('\u2192');
+    if (arrowIdx === -1) return;
+    const before = full.slice(0, arrowIdx).trimEnd();
+    const after = full.slice(arrowIdx + 1).trim();
+    const colonIdx = before.lastIndexOf(':');
+    if (colonIdx === -1) return;
+    const prefix = before.slice(0, colonIdx + 1) + ' ';
+    const oldText = before.slice(colonIdx + 1).trim();
+    return { prefix, oldText, newText: after };
+  }
+
+  private async runPs1() {
+    const g = this.game;
+    if (!g || !g.isPs1Launcher || !g.path || !g.gameId) return;
+
+    const newTitle = this.sanitize(this.ps1NewTitle || '');
+    if (!newTitle || this.ps1NewTitle.trim() === this.initialPs1NewTitle) return;
+
+    this.running = true;
+    this.ps1DialogState = 'running';
+    this.ps1Log = [];
+
+    this.addLog(`Renaming "${g.title}" → "${newTitle}"`, 'step');
+
+    window.libraryAPI.onRenamePs1Progress((progress) => {
+      const isChange = progress.stage.startsWith('Renaming VCD:')
+        || progress.stage.startsWith('Renaming VMC')
+        || progress.stage.startsWith('Renaming APPS folder')
+        || progress.stage.startsWith('Renaming ELF:')
+        || progress.stage.startsWith('Updating title.cfg');
+      if (isChange) {
+        const p = this.parseChangeMsg(progress.stage);
+        if (p) {
+          this.addLog(p.prefix, 'change', p.oldText, p.newText);
+        } else {
+          this.addLog(progress.stage, 'change');
+        }
+      } else {
+        this.addLog(progress.stage, 'info');
+      }
+    });
+
+    try {
+      this.addLog('Step 1 — Renaming folders', 'step');
+      const step1 = await window.libraryAPI.renamePs1LauncherStep1(
+        g.path, g.gameId, newTitle
+      );
+
+      if (!step1.success) {
+        this.addLog(`Failed: ${step1.message}`, 'error');
+        this.ps1DialogState = 'done';
+        this.running = false;
+        return;
+      }
+      this.addLog('Folders renamed', 'success');
+
+      if (step1.oldElfFile && step1.newElfFile && step1.oldElfFile !== step1.newElfFile) {
+        this.addLog('ELF: ', 'change', step1.oldElfFile, step1.newElfFile);
+      }
+
+      this.addLog('Step 2 — Updating APPS contents (ELF, title.cfg)', 'step');
+      const step2 = await window.libraryAPI.renamePs1LauncherStep2({
+        newAppsFolder: step1.newAppsFolder!,
+        oldElfFile: step1.oldElfFile,
+        newElfFile: step1.newElfFile,
+        newCfgContent: step1.newCfgContent,
+        newTitle,
+      });
+
+      if (step2.success) {
+        this.addLog('Internal changes applied', 'success');
+        this.addLog('Rename complete!', 'success');
+      } else {
+        this.addLog(`Failed: ${step2.message}`, 'error');
+      }
+
+      this.ps1DialogState = 'done';
+      this.running = false;
+    } catch (err: any) {
+      this.addLog(`Error: ${err?.message || err}`, 'error');
+      this.ps1DialogState = 'done';
+      this.running = false;
+    } finally {
+      window.libraryAPI.removeAllRenamePs1ProgressListeners();
+    }
+  }
+
   run() {
-    if (this.running || this.plan.length === 0) return;
-    // Hand the whole plan to the jobs queue — it renames serially and reports
-    // progress there. Close the dialog once everything is queued.
+    if (this.running) return;
+
+    if (this.isPs1Launcher && this.game) {
+      void this.runPs1();
+      return;
+    }
+
+    if (this.plan.length === 0) return;
     this._jobs.enqueue(
       this.plan.map(({ game }) => ({
         type: 'rename',

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
@@ -29,10 +29,12 @@ interface Ps1RenamePreview {
 }
 
 interface Ps1RenameProgress {
+  percent: number;
   stage: string;
 }
 
 interface LogEntry {
+  id: number;
   time: string;
   text: string;
   type: 'info' | 'success' | 'error' | 'step' | 'change';
@@ -68,10 +70,10 @@ export class LibraryRenameDialogComponent implements OnInit {
 
   private plan: RenamePlanItem[] = [];
   private candidates: Game[] = [];
+  private logEntryIdCounter = 0;
   private destroyed = false;
   private readonly _cdr = inject(ChangeDetectorRef);
   private readonly _destroyRef = inject(DestroyRef);
-  private progressCb: ((progress: Ps1RenameProgress) => void) | null = null;
 
   constructor(
     private readonly _libraryService: LibraryService,
@@ -111,7 +113,7 @@ export class LibraryRenameDialogComponent implements OnInit {
   }
 
   get ps1CloseAllowed(): boolean {
-    return !this.isPs1Launcher || this.ps1DialogState === 'input';
+    return !this.isPs1Launcher || this.ps1DialogState !== 'running';
   }
 
   get ps1VcdFilename(): string {
@@ -143,10 +145,7 @@ export class LibraryRenameDialogComponent implements OnInit {
 
     this._destroyRef.onDestroy(() => {
       this.destroyed = true;
-      if (this.progressCb) {
-        window.libraryAPI.removeAllRenamePs1ProgressListeners();
-        this.progressCb = null;
-      }
+      window.libraryAPI.removeAllRenamePs1ProgressListeners();
     });
   }
 
@@ -224,10 +223,11 @@ export class LibraryRenameDialogComponent implements OnInit {
   ) {
     const now = new Date();
     const time = now.toLocaleTimeString('en-US', { hour12: false });
+    const id = ++this.logEntryIdCounter;
     if (oldText !== undefined && newText !== undefined) {
-      this.ps1Log = [...this.ps1Log, { time, text, type, oldText, newText }];
+      this.ps1Log = [...this.ps1Log, { id, time, text, type, oldText, newText }];
     } else {
-      this.ps1Log = [...this.ps1Log, { time, text, type }];
+      this.ps1Log = [...this.ps1Log, { id, time, text, type }];
     }
     this._cdr.detectChanges();
     this.logAreaRef()?.nativeElement.scrollTo({ top: this.logAreaRef()?.nativeElement.scrollHeight ?? 0, behavior: 'instant' });
@@ -277,8 +277,7 @@ export class LibraryRenameDialogComponent implements OnInit {
         this.addLog(progress.stage, 'info');
       }
     };
-    this.progressCb = (progress) => handleProgress(progress);
-    window.libraryAPI.onRenamePs1Progress(this.progressCb);
+    window.libraryAPI.onRenamePs1Progress(handleProgress);
 
     try {
       this.addLog('Step 1 — Renaming folders', 'step');

--- a/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
+++ b/angular/src/app/pages/library/components/rename-dialog/rename-dialog.component.ts
@@ -1,9 +1,11 @@
 import {
+  ChangeDetectorRef,
   Component,
   DestroyRef,
   ElementRef,
   inject,
   input,
+  OnInit,
   output,
   viewChild,
 } from '@angular/core';
@@ -44,7 +46,7 @@ interface LogEntry {
   templateUrl: './rename-dialog.component.html',
   styleUrl: './rename-dialog.component.scss',
 })
-export class LibraryRenameDialogComponent {
+export class LibraryRenameDialogComponent implements OnInit {
   readonly game = input<Game>();
   readonly closed = output<void>();
   readonly logAreaRef = viewChild<ElementRef<HTMLElement>>('logArea');
@@ -67,6 +69,7 @@ export class LibraryRenameDialogComponent {
   private plan: RenamePlanItem[] = [];
   private candidates: Game[] = [];
   private destroyed = false;
+  private readonly _cdr = inject(ChangeDetectorRef);
   private readonly _destroyRef = inject(DestroyRef);
   private progressCb: ((progress: Ps1RenameProgress) => void) | null = null;
 
@@ -226,12 +229,8 @@ export class LibraryRenameDialogComponent {
     } else {
       this.ps1Log = [...this.ps1Log, { time, text, type }];
     }
-    requestAnimationFrame(() => {
-      this.logAreaRef()?.nativeElement.scrollTo({
-        top: this.logAreaRef()?.nativeElement.scrollHeight ?? 0,
-        behavior: 'instant',
-      });
-    });
+    this._cdr.detectChanges();
+    this.logAreaRef()?.nativeElement.scrollTo({ top: this.logAreaRef()?.nativeElement.scrollHeight ?? 0, behavior: 'instant' });
   }
 
   private parseChangeMsg(full: string) {
@@ -257,10 +256,9 @@ export class LibraryRenameDialogComponent {
     this.running = true;
     this.ps1DialogState = 'running';
     this.ps1Log = [];
-
     this.addLog(`Renaming "${g.title}" → "${newTitle}"`, 'step');
 
-    this.progressCb = (progress) => {
+    const handleProgress = (progress: Ps1RenameProgress) => {
       if (this.destroyed) return;
       const isChange =
         progress.stage.startsWith('Renaming VCD:') ||
@@ -279,6 +277,7 @@ export class LibraryRenameDialogComponent {
         this.addLog(progress.stage, 'info');
       }
     };
+    this.progressCb = (progress) => handleProgress(progress);
     window.libraryAPI.onRenamePs1Progress(this.progressCb);
 
     try {
@@ -296,14 +295,6 @@ export class LibraryRenameDialogComponent {
         return;
       }
       this.addLog('Folders renamed', 'success');
-
-      if (
-        step1.oldElfFile &&
-        step1.newElfFile &&
-        step1.oldElfFile !== step1.newElfFile
-      ) {
-        this.addLog('ELF: ', 'change', step1.oldElfFile, step1.newElfFile);
-      }
 
       if (!step1.newAppsFolder) {
         this.addLog('Internal error: newAppsFolder missing', 'error');
@@ -337,6 +328,7 @@ export class LibraryRenameDialogComponent {
       this.running = false;
     } finally {
       window.libraryAPI.removeAllRenamePs1ProgressListeners();
+      if (!this.destroyed) this._cdr.detectChanges();
     }
   }
 

--- a/angular/src/app/pages/library/library.component.html
+++ b/angular/src/app/pages/library/library.component.html
@@ -99,7 +99,7 @@
   </header>
 
   <!-- ── System tabs ─────────────────────────────────────────── -->
-  <div class="flex items-center gap-2 px-6 pt-4">
+  <div class="flex items-center gap-2 px-6 py-4">
     <button
       class="seg-tab"
       [class.active]="isActive('PS2')"

--- a/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
+++ b/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
@@ -20,6 +20,13 @@
     @if (options().detail) {
     <p class="text-xs text-base-content/55 whitespace-pre-wrap">{{ options().detail }}</p>
     }
+    @if (options().checkboxLabel) {
+    <label class="flex items-center gap-3 cursor-pointer select-none mt-2 pt-2 border-t border-base-content/10">
+      <input type="checkbox" class="toggle toggle-primary" [ngModel]="checkboxChecked()"
+        (ngModelChange)="checkboxChecked.set($event)" />
+      <span class="text-xs text-base-content/70">{{ options().checkboxLabel }}</span>
+    </label>
+    }
   </div>
 
   <!-- Footer -->

--- a/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
+++ b/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
@@ -1,12 +1,6 @@
-<div class="cd-backdrop" (click)="close(false)"></div>
-<div
-  #modal
-  class="cd-modal glass-strong"
-  role="dialog"
-  aria-modal="true"
-  [attr.aria-label]="options().title"
-  (keydown)="onKeydown($event)"
->
+<div class="cd-backdrop" (click)="options().backdropClose !== false && close(false)"></div>
+<div #modal class="cd-modal glass-strong" role="dialog" aria-modal="true" [attr.aria-label]="options().title"
+  (keydown)="onKeydown($event)">
   <!-- Header -->
   <div class="flex items-center gap-2 border-b border-base-content/10 px-5 py-3">
     <i-lucide name="triangle-alert" size="18" class="text-error"></i-lucide>
@@ -24,7 +18,7 @@
   <div class="flex flex-col gap-3 px-5 py-4">
     <p class="text-sm leading-relaxed">{{ options().message }}</p>
     @if (options().detail) {
-      <p class="text-xs text-base-content/55 whitespace-pre-wrap">{{ options().detail }}</p>
+    <p class="text-xs text-base-content/55 whitespace-pre-wrap">{{ options().detail }}</p>
     }
   </div>
 

--- a/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
+++ b/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
@@ -1,0 +1,40 @@
+<div class="cd-backdrop" (click)="close(false)"></div>
+<div
+  #modal
+  class="cd-modal glass-strong"
+  role="dialog"
+  aria-modal="true"
+  [attr.aria-label]="options().title"
+  (keydown)="onKeydown($event)"
+>
+  <!-- Header -->
+  <div class="flex items-center gap-2 border-b border-base-content/10 px-5 py-3">
+    <i-lucide name="triangle-alert" size="18" class="text-error"></i-lucide>
+    <div class="min-w-0">
+      <h2 class="truncate font-display text-sm font-semibold tracking-wide">
+        {{ options().title }}
+      </h2>
+    </div>
+    <button class="btn btn-ghost btn-xs btn-square ml-auto" (click)="close(false)">
+      <i-lucide name="x" size="16"></i-lucide>
+    </button>
+  </div>
+
+  <!-- Body -->
+  <div class="flex flex-col gap-3 px-5 py-4">
+    <p class="text-sm leading-relaxed">{{ options().message }}</p>
+    @if (options().detail) {
+      <p class="text-xs text-base-content/55 whitespace-pre-wrap">{{ options().detail }}</p>
+    }
+  </div>
+
+  <!-- Footer -->
+  <div class="flex justify-end gap-2 border-t border-base-content/10 px-5 py-3">
+    <button #cancelBtn class="btn btn-ghost btn-sm" (click)="close(false)">
+      {{ options().cancelLabel || 'Cancel' }}
+    </button>
+    <button class="btn btn-error btn-sm" (click)="close(true)">
+      {{ options().confirmLabel || 'OK' }}
+    </button>
+  </div>
+</div>

--- a/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
+++ b/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.html
@@ -20,11 +20,11 @@
     @if (options().detail) {
     <p class="text-xs text-base-content/55 whitespace-pre-wrap">{{ options().detail }}</p>
     }
-    @if (options().checkboxLabel) {
+    @if (options().toggleLabel) {
     <label class="flex items-center gap-3 cursor-pointer select-none mt-2 pt-2 border-t border-base-content/10">
       <input type="checkbox" class="toggle toggle-primary" [ngModel]="checkboxChecked()"
         (ngModelChange)="checkboxChecked.set($event)" />
-      <span class="text-xs text-base-content/70">{{ options().checkboxLabel }}</span>
+      <span class="text-xs text-base-content/70">{{ options().toggleLabel }}</span>
     </label>
     }
   </div>

--- a/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.scss
+++ b/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.scss
@@ -1,0 +1,23 @@
+:host {
+  display: contents;
+}
+
+.cd-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+}
+
+.cd-modal {
+  position: fixed;
+  z-index: 51;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(24rem, calc(100vw - 2rem));
+  border-radius: 1rem;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+  overflow: hidden;
+}

--- a/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,15 +1,18 @@
-import { Component, ElementRef, afterNextRender, input, viewChild } from '@angular/core';
+import { Component, ElementRef, afterNextRender, input, signal, viewChild } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { LucideAngularModule } from 'lucide-angular';
 import type { ConfirmDialogOptions } from '../../services/confirm-dialog.service';
 
 @Component({
   selector: 'app-confirm-dialog',
-  imports: [LucideAngularModule],
+  imports: [LucideAngularModule, FormsModule],
   templateUrl: './confirm-dialog.component.html',
   styleUrl: './confirm-dialog.component.scss',
 })
 export class ConfirmDialogComponent {
   readonly options = input.required<ConfirmDialogOptions>();
+
+  readonly checkboxChecked = signal(false);
 
   private readonly cancelBtn = viewChild.required<ElementRef<HTMLButtonElement>>('cancelBtn');
 

--- a/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
+++ b/angular/src/app/shared/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,37 @@
+import { Component, ElementRef, afterNextRender, input, viewChild } from '@angular/core';
+import { LucideAngularModule } from 'lucide-angular';
+import type { ConfirmDialogOptions } from '../../services/confirm-dialog.service';
+
+@Component({
+  selector: 'app-confirm-dialog',
+  imports: [LucideAngularModule],
+  templateUrl: './confirm-dialog.component.html',
+  styleUrl: './confirm-dialog.component.scss',
+})
+export class ConfirmDialogComponent {
+  readonly options = input.required<ConfirmDialogOptions>();
+
+  private readonly cancelBtn = viewChild.required<ElementRef<HTMLButtonElement>>('cancelBtn');
+
+  private _closeCallback: ((result: boolean) => void) | null = null;
+
+  /** Set by the service to receive the close result directly. */
+  setCloseCallback(cb: (result: boolean) => void): void {
+    this._closeCallback = cb;
+  }
+
+  constructor() {
+    afterNextRender(() => this.cancelBtn().nativeElement.focus());
+  }
+
+  onKeydown(event: KeyboardEvent): void {
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      this.close(false);
+    }
+  }
+
+  close(result: boolean): void {
+    this._closeCallback?.(result);
+  }
+}

--- a/angular/src/app/shared/components/jobs-panel/jobs-panel.component.html
+++ b/angular/src/app/shared/components/jobs-panel/jobs-panel.component.html
@@ -41,6 +41,7 @@
         class="rounded-md border border-base-content/10 bg-base-100/40 p-2.5"
         [class.border-error]="job.status === 'error'"
         [class.border-success]="job.status === 'success'"
+        [class.border-warning]="job.status === 'cancelled'"
       >
         <div class="flex items-center gap-2">
           <i-lucide
@@ -49,12 +50,13 @@
             [class.text-success]="job.status === 'success'"
             [class.text-error]="job.status === 'error'"
             [class.text-accent]="job.status === 'running'"
+            [class.text-warning]="job.status === 'cancelled'"
             [class.text-base-content]="job.status === 'queued'"
             [class.spin]="job.status === 'running'"
           ></i-lucide>
           <span class="truncate text-xs font-medium" [title]="job.label">{{ job.label }}</span>
           <span class="badge badge-ghost badge-xs ml-auto shrink-0">{{ typeLabel(job) }}</span>
-          @if (job.status === 'success' || job.status === 'error' || job.status === 'queued') {
+          @if (job.status === 'success' || job.status === 'error' || job.status === 'queued' || job.status === 'cancelled') {
           <button
             class="btn btn-ghost btn-xs btn-square shrink-0"
             (click)="_jobs.removeJob(job.id)"
@@ -74,6 +76,12 @@
         <p class="mt-1 truncate text-[0.68rem] text-base-content/55">{{ job.stage }}</p>
         } @else if (job.status === 'queued') {
         <p class="mt-1 text-[0.68rem] text-base-content/45">Queued</p>
+        } @else if (job.status === 'success') {
+        @if (job.message) {
+        <p class="mt-1 text-[0.68rem] text-success/70">{{ job.message }}</p>
+        }
+        } @else if (job.status === 'cancelled') {
+        <p class="mt-1 text-[0.68rem] text-warning/70">{{ job.message || 'Cancelled' }}</p>
         } @else if (job.status === 'error') {
         <p class="mt-1 text-[0.68rem] text-error" [title]="job.message">{{ job.message }}</p>
         }

--- a/angular/src/app/shared/components/jobs-panel/jobs-panel.component.ts
+++ b/angular/src/app/shared/components/jobs-panel/jobs-panel.component.ts
@@ -1,11 +1,7 @@
-import { Component, OnDestroy } from '@angular/core';
+import { Component, DestroyRef, inject } from '@angular/core';
 import { AsyncPipe } from '@angular/common';
 import { LucideAngularModule } from 'lucide-angular';
-import { Subscription } from 'rxjs';
-import {
-  ImportJob,
-  JobsService,
-} from '../../services/jobs.service';
+import { ImportJob, JobsService } from '../../services/jobs.service';
 
 @Component({
   selector: 'app-jobs-panel',
@@ -13,21 +9,17 @@ import {
   templateUrl: './jobs-panel.component.html',
   styleUrl: './jobs-panel.component.scss',
 })
-export class JobsPanelComponent implements OnDestroy {
+export class JobsPanelComponent {
   public collapsed = true;
-  private sub: Subscription;
 
   constructor(public _jobs: JobsService) {
-    // Auto-expand the panel whenever work is in flight.
-    this.sub = this._jobs.activeCount$.subscribe((count) => {
+    const destroyRef = inject(DestroyRef);
+    const sub = this._jobs.activeCount$.subscribe((count) => {
       if (count > 0) {
         this.collapsed = false;
       }
     });
-  }
-
-  ngOnDestroy(): void {
-    this.sub.unsubscribe();
+    destroyRef.onDestroy(() => sub.unsubscribe());
   }
 
   toggle() {
@@ -65,6 +57,8 @@ export class JobsPanelComponent implements OnDestroy {
         return 'circle-x';
       case 'running':
         return 'loader';
+      case 'cancelled':
+        return 'ban';
       default:
         return 'clock';
     }

--- a/angular/src/app/shared/services/confirm-dialog.service.ts
+++ b/angular/src/app/shared/services/confirm-dialog.service.ts
@@ -16,8 +16,8 @@ export interface ConfirmDialogOptions {
   cancelLabel?: string;
   /** Allow closing by clicking the backdrop. Defaults to true. */
   backdropClose?: boolean;
-  /** If set, renders a checkbox with this label text. */
-  checkboxLabel?: string;
+  /** If set, renders a toggle switch with this label text. */
+  toggleLabel?: string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -57,7 +57,9 @@ export class ConfirmDialogService {
     });
   }
 
-  confirmWithCheckbox(options: ConfirmDialogOptions): Promise<{ confirmed: boolean; checked: boolean }> {
+  confirmWithCheckbox(
+    options: ConfirmDialogOptions,
+  ): Promise<{ confirmed: boolean; checked: boolean }> {
     if (!isPlatformBrowser(this.platformId)) {
       return Promise.resolve({ confirmed: false, checked: false });
     }

--- a/angular/src/app/shared/services/confirm-dialog.service.ts
+++ b/angular/src/app/shared/services/confirm-dialog.service.ts
@@ -1,0 +1,55 @@
+import { isPlatformBrowser } from '@angular/common';
+import {
+  ApplicationRef,
+  Injectable,
+  PLATFORM_ID,
+  createComponent,
+  inject,
+} from '@angular/core';
+import { ConfirmDialogComponent } from '../components/confirm-dialog/confirm-dialog.component';
+
+export interface ConfirmDialogOptions {
+  title: string;
+  message: string;
+  detail?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+}
+
+@Injectable({ providedIn: 'root' })
+export class ConfirmDialogService {
+  private readonly appRef = inject(ApplicationRef);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  confirm(options: ConfirmDialogOptions): Promise<boolean> {
+    // SSR guard — the dialog needs the DOM to mount.
+    if (!isPlatformBrowser(this.platformId)) {
+      return Promise.resolve(false);
+    }
+
+    const componentRef = createComponent(ConfirmDialogComponent, {
+      environmentInjector: this.appRef.injector,
+    });
+
+    componentRef.setInput('options', options);
+    document.body.appendChild(componentRef.location.nativeElement);
+
+    this.appRef.attachView(componentRef.hostView);
+    componentRef.changeDetectorRef.detectChanges();
+
+    return new Promise<boolean>((resolve) => {
+      let resolved = false;
+
+      componentRef.instance.setCloseCallback((result: boolean) => {
+        if (resolved) return;
+        resolved = true;
+
+        queueMicrotask(() => {
+          this.appRef.detachView(componentRef.hostView);
+          componentRef.destroy();
+        });
+        resolve(result);
+      });
+    });
+  }
+}

--- a/angular/src/app/shared/services/confirm-dialog.service.ts
+++ b/angular/src/app/shared/services/confirm-dialog.service.ts
@@ -16,6 +16,8 @@ export interface ConfirmDialogOptions {
   cancelLabel?: string;
   /** Allow closing by clicking the backdrop. Defaults to true. */
   backdropClose?: boolean;
+  /** If set, renders a checkbox with this label text. */
+  checkboxLabel?: string;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -51,6 +53,38 @@ export class ConfirmDialogService {
           componentRef.destroy();
         });
         resolve(result);
+      });
+    });
+  }
+
+  confirmWithCheckbox(options: ConfirmDialogOptions): Promise<{ confirmed: boolean; checked: boolean }> {
+    if (!isPlatformBrowser(this.platformId)) {
+      return Promise.resolve({ confirmed: false, checked: false });
+    }
+
+    const componentRef = createComponent(ConfirmDialogComponent, {
+      environmentInjector: this.appRef.injector,
+    });
+
+    componentRef.setInput('options', options);
+    document.body.appendChild(componentRef.location.nativeElement);
+
+    this.appRef.attachView(componentRef.hostView);
+    componentRef.changeDetectorRef.detectChanges();
+
+    return new Promise<{ confirmed: boolean; checked: boolean }>((resolve) => {
+      let resolved = false;
+
+      componentRef.instance.setCloseCallback((result: boolean) => {
+        if (resolved) return;
+        resolved = true;
+
+        const checked = componentRef.instance.checkboxChecked();
+        queueMicrotask(() => {
+          this.appRef.detachView(componentRef.hostView);
+          componentRef.destroy();
+        });
+        resolve({ confirmed: result, checked });
       });
     });
   }

--- a/angular/src/app/shared/services/confirm-dialog.service.ts
+++ b/angular/src/app/shared/services/confirm-dialog.service.ts
@@ -14,6 +14,8 @@ export interface ConfirmDialogOptions {
   detail?: string;
   confirmLabel?: string;
   cancelLabel?: string;
+  /** Allow closing by clicking the backdrop. Defaults to true. */
+  backdropClose?: boolean;
 }
 
 @Injectable({ providedIn: 'root' })

--- a/angular/src/app/shared/services/jobs.service.ts
+++ b/angular/src/app/shared/services/jobs.service.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable, map } from 'rxjs';
 import { LogsService } from './logs.service';
 import { LibraryService } from './library.service';
+import { ConfirmDialogService } from './confirm-dialog.service';
 
 export type ImportJobType =
   | 'ps2-dvd'
@@ -11,7 +12,7 @@ export type ImportJobType =
   | 'apps'
   | 'artwork'
   | 'rename';
-export type JobStatus = 'queued' | 'running' | 'success' | 'error';
+export type JobStatus = 'queued' | 'running' | 'success' | 'error' | 'cancelled';
 
 export interface ImportJob {
   id: string;
@@ -34,6 +35,13 @@ export interface ImportJob {
    * SYSTEM.CNF).
    */
   keepOriginalName?: boolean;
+  /**
+   * Artwork only: overrides the local filename stem (sans _COV.png suffix).
+   * For PS1 launcher apps this is the boot ELF name (e.g.
+   * "XX.SCUS_944.02.SomeGame.ELF") so the saved file matches the art
+   * matching logic in updateArtForGame.
+   */
+  saveAsName?: string;
   status: JobStatus;
   percent: number;
   stage: string;
@@ -75,7 +83,8 @@ export class JobsService {
 
   constructor(
     private readonly _logger: LogsService,
-    private readonly _library: LibraryService
+    private readonly _library: LibraryService,
+    private readonly _confirm: ConfirmDialogService
   ) {}
 
   /** Queue one or more imports and kick the worker if idle. */
@@ -133,18 +142,27 @@ export class JobsService {
 
     try {
       const result = await this.runJob(next);
-      if (result?.success) {
+      if (result?.cancelled) {
+        this.patchJob(next.id, {
+          status: 'cancelled',
+          percent: 100,
+          stage: 'Cancelled',
+          finishedAt: Date.now(),
+        });
+        this._logger.log('jobsService', `Job cancelled: ${next.label}`);
+      } else if (result?.success) {
         this.patchJob(next.id, {
           status: 'success',
           percent: 100,
           stage: 'Completed',
+          message: result?.message,
           finishedAt: Date.now(),
         });
         this._logger.log('jobsService', `Job succeeded: ${next.label}`);
         // Artwork only touches one game's images — patch it in place so the
         // library scroll position is preserved. Everything else changes the
         // file set on disk and needs a full re-scan.
-        if (next.type === 'artwork') {
+        if (next.type === 'artwork' && result?.artRefresh !== false) {
           void this._library.updateArtForGame(next.gameId);
         } else {
           this._library.refreshGamesFiles();
@@ -158,7 +176,7 @@ export class JobsService {
         });
         this._logger.error(
           'jobsService',
-          `Import failed for ${next.label}: ${result?.message}`
+          `Job failed for ${next.label} (${next.type}): ${result?.message}`
         );
       }
     } catch (error: any) {
@@ -170,7 +188,7 @@ export class JobsService {
       });
       this._logger.error(
         'jobsService',
-        `Import error for ${next.label}: ${error?.message || error}`
+        `Job threw for ${next.label} (${next.type}): ${error?.message || error}`
       );
     } finally {
       this.isProcessing = false;
@@ -181,7 +199,7 @@ export class JobsService {
 
   private async runJob(
     job: ImportJob
-  ): Promise<{ success: boolean; message?: string }> {
+  ): Promise<{ success: boolean; message?: string; artRefresh?: boolean; cancelled?: boolean }> {
     const dirPath = this._library.currentDirectoryValue;
     if (!dirPath) {
       return { success: false, message: 'No library directory mounted.' };
@@ -212,12 +230,96 @@ export class JobsService {
   }
 
   private async runArtworkJob(job: ImportJob, dirPath: string) {
-    this.patchJob(job.id, { stage: 'Downloading artwork…', percent: 50 });
-    return window.libraryAPI.downloadArtByGameId(
-      `${dirPath}/ART`,
-      job.gameId,
-      job.system ?? 'PS2'
+    this.patchJob(job.id, { stage: 'Checking existing artwork…', percent: 10 });
+
+    const artDir = `${dirPath}/ART`;
+    const saveAsName = job.saveAsName;
+    const localName = saveAsName || job.gameId;
+    const types = ['COV', 'ICO', 'SCR'];
+    const expectedFiles = types.map((t) => `${localName}_${t}.png`);
+
+    this._logger.log(
+      'jobsService',
+      `FetchArtwork for "${job.label}": gameId=${job.gameId}, saveAsName=${saveAsName ?? '(none)'}, localName=${localName}, expectedFiles=[${expectedFiles.join(', ')}]`
     );
+
+    const existing = await window.libraryAPI.checkArtFilesExist(artDir, expectedFiles);
+
+    this._logger.log(
+      'jobsService',
+      `checkArtFilesExist returned ${existing.length} existing file(s) for "${job.label}": [${existing.join(', ')}]`
+    );
+
+    let shouldDownload = true;
+    let isOverwrite = false;
+
+    if (existing.length > 0) {
+      const confirmed = await this._confirm.confirm({
+        title: 'Overwrite Artwork',
+        message: `Artwork already exists for "${job.label}". Overwrite?`,
+        detail: existing.join('\n'),
+        confirmLabel: 'Overwrite',
+      });
+      this._logger.log(
+        'jobsService',
+        `Confirm dialog result for "${job.label}": confirmed=${confirmed}`
+      );
+      if (confirmed) {
+        isOverwrite = true;
+      } else {
+        shouldDownload = false;
+      }
+    }
+
+    if (!shouldDownload) {
+      this._logger.log(
+        'jobsService',
+        `Artwork download cancelled by user for "${job.label}" — existing files left untouched`
+      );
+      return { success: false, cancelled: true, message: 'Cancelled by user.' };
+    }
+
+    this.patchJob(job.id, { stage: 'Downloading artwork…', percent: 50 });
+
+    const result = await window.libraryAPI.downloadArtByGameId(
+      artDir,
+      job.gameId,
+      job.system ?? 'PS2',
+      saveAsName
+    );
+
+    if (result?.data) {
+      const saved = result.data.filter((r: any) => r.savedPath);
+      const failed = result.data.filter((r: any) => r.error);
+      this._logger.log(
+        'jobsService',
+        `Artwork download complete for "${job.label}": ${saved.length} saved, ${failed.length} failed`
+      );
+      if (saveAsName && saveAsName !== job.gameId) {
+        this._logger.log(
+          'jobsService',
+          `Artwork saved with name pattern "${saveAsName}_*.png" (gameId: ${job.gameId})`
+        );
+      }
+      for (const item of saved) {
+        this._logger.log('jobsService', `  ✓ ${item.type}: ${item.savedPath}`);
+      }
+      for (const item of failed) {
+        this._logger.log('jobsService', `  ✗ ${item.type}: ${item.error}`);
+      }
+
+      if (saved.length === 0) {
+        return {
+          success: false,
+          message: `No artwork found for ${job.label} (${job.gameId}) in the ${job.system ?? 'PS2'} database.`,
+        };
+      }
+    }
+
+    const message = isOverwrite
+      ? 'Artwork overwritten.'
+      : 'Artwork downloaded.';
+    return { success: true, message };
   }
 
   private async runRenameJob(job: ImportJob) {

--- a/angular/src/app/shared/services/jobs.service.ts
+++ b/angular/src/app/shared/services/jobs.service.ts
@@ -12,7 +12,12 @@ export type ImportJobType =
   | 'apps'
   | 'artwork'
   | 'rename';
-export type JobStatus = 'queued' | 'running' | 'success' | 'error' | 'cancelled';
+export type JobStatus =
+  | 'queued'
+  | 'running'
+  | 'success'
+  | 'error'
+  | 'cancelled';
 
 export interface ImportJob {
   id: string;
@@ -74,8 +79,8 @@ export class JobsService {
       map(
         (jobs) =>
           jobs.filter((j) => j.status === 'queued' || j.status === 'running')
-            .length
-      )
+            .length,
+      ),
     );
   }
 
@@ -84,7 +89,7 @@ export class JobsService {
   constructor(
     private readonly _logger: LogsService,
     private readonly _library: LibraryService,
-    private readonly _confirm: ConfirmDialogService
+    private readonly _confirm: ConfirmDialogService,
   ) {}
 
   /** Queue one or more imports and kick the worker if idle. */
@@ -106,8 +111,8 @@ export class JobsService {
   public clearFinished(): void {
     this.jobsSubject.next(
       this.jobsSubject.value.filter(
-        (j) => j.status === 'queued' || j.status === 'running'
-      )
+        (j) => j.status === 'queued' || j.status === 'running',
+      ),
     );
   }
 
@@ -115,16 +120,14 @@ export class JobsService {
   public removeJob(id: string): void {
     this.jobsSubject.next(
       this.jobsSubject.value.filter(
-        (j) => j.id !== id || j.status === 'running'
-      )
+        (j) => j.id !== id || j.status === 'running',
+      ),
     );
   }
 
   private patchJob(id: string, patch: Partial<ImportJob>): void {
     this.jobsSubject.next(
-      this.jobsSubject.value.map((j) =>
-        j.id === id ? { ...j, ...patch } : j
-      )
+      this.jobsSubject.value.map((j) => (j.id === id ? { ...j, ...patch } : j)),
     );
   }
 
@@ -138,7 +141,11 @@ export class JobsService {
     }
 
     this.isProcessing = true;
-    this.patchJob(next.id, { status: 'running', stage: 'Starting…', percent: 0 });
+    this.patchJob(next.id, {
+      status: 'running',
+      stage: 'Starting…',
+      percent: 0,
+    });
 
     try {
       const result = await this.runJob(next);
@@ -176,7 +183,7 @@ export class JobsService {
         });
         this._logger.error(
           'jobsService',
-          `Job failed for ${next.label} (${next.type}): ${result?.message}`
+          `Job failed for ${next.label} (${next.type}): ${result?.message}`,
         );
       }
     } catch (error: any) {
@@ -188,7 +195,7 @@ export class JobsService {
       });
       this._logger.error(
         'jobsService',
-        `Job threw for ${next.label} (${next.type}): ${error?.message || error}`
+        `Job threw for ${next.label} (${next.type}): ${error?.message || error}`,
       );
     } finally {
       this.isProcessing = false;
@@ -198,8 +205,13 @@ export class JobsService {
   }
 
   private async runJob(
-    job: ImportJob
-  ): Promise<{ success: boolean; message?: string; artRefresh?: boolean; cancelled?: boolean }> {
+    job: ImportJob,
+  ): Promise<{
+    success: boolean;
+    message?: string;
+    artRefresh?: boolean;
+    cancelled?: boolean;
+  }> {
     const dirPath = this._library.currentDirectoryValue;
     if (!dirPath) {
       return { success: false, message: 'No library directory mounted.' };
@@ -240,14 +252,17 @@ export class JobsService {
 
     this._logger.log(
       'jobsService',
-      `FetchArtwork for "${job.label}": gameId=${job.gameId}, saveAsName=${saveAsName ?? '(none)'}, localName=${localName}, expectedFiles=[${expectedFiles.join(', ')}]`
+      `FetchArtwork for "${job.label}": gameId=${job.gameId}, saveAsName=${saveAsName ?? '(none)'}, localName=${localName}, expectedFiles=[${expectedFiles.join(', ')}]`,
     );
 
-    const existing = await window.libraryAPI.checkArtFilesExist(artDir, expectedFiles);
+    const existing = await window.libraryAPI.checkArtFilesExist(
+      artDir,
+      expectedFiles,
+    );
 
     this._logger.log(
       'jobsService',
-      `checkArtFilesExist returned ${existing.length} existing file(s) for "${job.label}": [${existing.join(', ')}]`
+      `checkArtFilesExist returned ${existing.length} existing file(s) for "${job.label}": [${existing.join(', ')}]`,
     );
 
     let shouldDownload = true;
@@ -262,7 +277,7 @@ export class JobsService {
       });
       this._logger.log(
         'jobsService',
-        `Confirm dialog result for "${job.label}": confirmed=${confirmed}`
+        `Confirm dialog result for "${job.label}": confirmed=${confirmed}`,
       );
       if (confirmed) {
         isOverwrite = true;
@@ -274,7 +289,7 @@ export class JobsService {
     if (!shouldDownload) {
       this._logger.log(
         'jobsService',
-        `Artwork download cancelled by user for "${job.label}" — existing files left untouched`
+        `Artwork download cancelled by user for "${job.label}" — existing files left untouched`,
       );
       return { success: false, cancelled: true, message: 'Cancelled by user.' };
     }
@@ -285,7 +300,7 @@ export class JobsService {
       artDir,
       job.gameId,
       job.system ?? 'PS2',
-      saveAsName
+      saveAsName,
     );
 
     if (result?.data) {
@@ -293,12 +308,12 @@ export class JobsService {
       const failed = result.data.filter((r: any) => r.error);
       this._logger.log(
         'jobsService',
-        `Artwork download complete for "${job.label}": ${saved.length} saved, ${failed.length} failed`
+        `Artwork download complete for "${job.label}": ${saved.length} saved, ${failed.length} failed`,
       );
       if (saveAsName && saveAsName !== job.gameId) {
         this._logger.log(
           'jobsService',
-          `Artwork saved with name pattern "${saveAsName}_*.png" (gameId: ${job.gameId})`
+          `Artwork saved with name pattern "${saveAsName}_*.png" (gameId: ${job.gameId})`,
         );
       }
       for (const item of saved) {
@@ -329,7 +344,7 @@ export class JobsService {
       job.filePath,
       job.gameId,
       job.gameName,
-      !!job.keepOriginalName
+      !!job.keepOriginalName,
     );
   }
 
@@ -339,13 +354,13 @@ export class JobsService {
       this.patchJob(job.id, {
         percent: progress.percent,
         stage: progress.stage,
-      })
+      }),
     );
     try {
       return await window.libraryAPI.compressIsoToZso(
         job.filePath,
         zsoPath,
-        job.deleteOriginal ?? true
+        job.deleteOriginal ?? true,
       );
     } finally {
       window.libraryAPI.removeAllZsoCompressProgressListeners();
@@ -357,7 +372,7 @@ export class JobsService {
       this.patchJob(job.id, {
         percent: progress.percent,
         stage: progress.stage,
-      })
+      }),
     );
     try {
       return await window.libraryAPI.importPs2CdGame(
@@ -365,7 +380,7 @@ export class JobsService {
         dirPath,
         job.gameId,
         job.gameName,
-        job.downloadArtwork
+        job.downloadArtwork,
       );
     } finally {
       window.libraryAPI.removeAllPs2CdImportProgressListeners();
@@ -377,14 +392,14 @@ export class JobsService {
       this.patchJob(job.id, {
         percent: progress.percent,
         stage: progress.stage,
-      })
+      }),
     );
     try {
       return await window.libraryAPI.importPs1Game(
         job.filePath,
         dirPath,
         job.elfPrefix || 'XX.',
-        job.downloadArtwork
+        job.downloadArtwork,
       );
     } finally {
       window.libraryAPI.removeAllPs1ImportProgressListeners();
@@ -392,20 +407,21 @@ export class JobsService {
   }
 
   private async runPs2DvdJob(job: ImportJob, dirPath: string) {
-    const destinationDir = `${dirPath}/DVD`;
+    const sep = dirPath.includes('\\') ? '\\' : '/';
+    const destinationDir = `${dirPath.replace(/[\\/]$/, '')}${sep}DVD`;
 
     window.libraryAPI.onMoveFileProgress((progress) =>
       this.patchJob(job.id, {
         percent: progress.percent,
         stage: `Copying ${progress.copiedMB}/${progress.totalMB} MB`,
-      })
+      }),
     );
 
     try {
       this.patchJob(job.id, { stage: 'Copying file…' });
       const moveResult: any = await window.libraryAPI.moveFile(
         job.filePath,
-        destinationDir
+        destinationDir,
       );
       if (!moveResult?.success) {
         return {
@@ -416,7 +432,7 @@ export class JobsService {
 
       const movedPath =
         moveResult.newPath ||
-        `${destinationDir}/${job.filePath.split(/[\\/]/).pop()}`;
+        `${destinationDir}${sep}${job.filePath.split(/[\\/]/).pop()}`;
 
       this.patchJob(job.id, { stage: 'Renaming…' });
       // In "new OPL convention" mode the rename drops the GAMEID. prefix so
@@ -425,7 +441,7 @@ export class JobsService {
         movedPath,
         job.gameId,
         job.gameName,
-        !!job.keepOriginalName
+        !!job.keepOriginalName,
       );
       if (!renameResult?.success) {
         return {
@@ -439,7 +455,7 @@ export class JobsService {
         await window.libraryAPI.downloadArtByGameId(
           `${dirPath}/ART`,
           job.gameId,
-          'PS2'
+          'PS2',
         );
       }
 

--- a/angular/src/app/shared/services/library.service.ts
+++ b/angular/src/app/shared/services/library.service.ts
@@ -574,6 +574,11 @@ export class LibraryService {
         game.art = artFiles.filter(
           (art: gameArt) => art.name === bootName + '_' + (art.type || ''),
         );
+      } else if (game.system === 'APPS' && game.filename) {
+        // Regular ELF apps: art files follow <boot>.ELF_<TYPE>.png convention
+        game.art = artFiles.filter(
+          (art: gameArt) => art.gameId === game.filename,
+        );
       } else {
         game.art = artFiles.filter(
           (art: gameArt) => art.gameId === game.gameId,

--- a/angular/src/app/shared/services/library.service.ts
+++ b/angular/src/app/shared/services/library.service.ts
@@ -861,6 +861,7 @@ export class LibraryService {
       return result;
     } catch (error: any) {
       this._logger.error('deleteGame', `Error: ${error?.message || error}`);
+      return { success: false, entries: [], message: error?.message ?? String(error) };
     } finally {
       this.setCurrentAction('');
       this.setLoading(false);

--- a/angular/src/app/shared/services/library.service.ts
+++ b/angular/src/app/shared/services/library.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { LogsService } from './logs.service';
 import { SettingsService } from './settings.service';
 import { BehaviorSubject, map, Observable } from 'rxjs';
-import { Game, GameFormat, RawGameFile, gameArt } from '../types/game.type';
+import { Game, GameFormat, Ps1LauncherInfo, RawGameFile, gameArt } from '../types/game.type';
 
 @Injectable({
   providedIn: 'root',
@@ -295,7 +295,7 @@ export class LibraryService {
             ps1LaunchersResult?.success && ps1LaunchersResult.launchers
               ? ps1LaunchersResult.launchers
               : [];
-          const ps1LauncherMap = new Map<string, { folder: string; title: string; boot: string; path: string; gameId?: string }>();
+          const ps1LauncherMap = new Map<string, Ps1LauncherInfo>();
           for (const launcher of ps1Launchers) {
             const name = launcher.folder.replace(/^POPS_/i, '');
             ps1LauncherMap.set(name.toLowerCase(), launcher);
@@ -484,7 +484,7 @@ export class LibraryService {
    */
   private async parseSingleFile(
     file: RawGameFile,
-    ps1LauncherMap?: Map<string, { folder: string; title: string; boot: string; path: string; gameId?: string }>
+    ps1LauncherMap?: Map<string, Ps1LauncherInfo>
   ): Promise<Game | null> {
     const gameIdMatch = file.name.match(/^([A-Z]{4}_\d{3}\.\d{2})\.(.+)$/i);
     const ext = file.extension?.toLowerCase();
@@ -501,7 +501,7 @@ export class LibraryService {
 
     let gameId: string;
     let title: string;
-    let ps1Launcher: { folder: string; title: string; boot: string; path: string; gameId?: string } | undefined;
+    let ps1Launcher: Ps1LauncherInfo | undefined;
 
     if (gameIdMatch) {
       gameId = gameIdMatch[1];
@@ -516,19 +516,18 @@ export class LibraryService {
       gameId = resolved.gameId;
       title = resolved.gameName || file.name;
     } else {
-      this.setCurrentAction(`Resolving VCD ${file.name}…`);
-      const resolved = await window.libraryAPI.tryDeterminePs1GameIdFromVcd(file.path);
       if (ps1LauncherMap) {
         ps1Launcher = ps1LauncherMap.get(file.name.toLowerCase());
       }
-      if (resolved?.success && resolved.gameId) {
-        gameId = resolved.gameId;
-        title = resolved.gameName || file.name;
-      } else if (ps1Launcher?.gameId) {
+      if (ps1Launcher?.gameId) {
         gameId = ps1Launcher.gameId;
         title = file.name;
       } else {
-        return null;
+        this.setCurrentAction(`Resolving VCD ${file.name}…`);
+        const resolved = await window.libraryAPI.tryDeterminePs1GameIdFromVcd(file.path);
+        if (!resolved?.success || !resolved.gameId) return null;
+        gameId = resolved.gameId;
+        title = resolved.gameName || file.name;
       }
     }
 
@@ -552,12 +551,13 @@ export class LibraryService {
     };
 
     if (hasLauncher) {
-      gameEntry.title = ps1Launcher!.title;
-      gameEntry.ps1LauncherPath = ps1Launcher!.path.replace(/[\\/][^\\/]+\.elf$/i, '');
-      gameEntry.ps1LauncherBoot = ps1Launcher!.boot;
+      const l = ps1Launcher!;
+      gameEntry.title = l.title;
+      gameEntry.ps1LauncherPath = l.path.replace(/[\\/][^\\/]+\.elf$/i, '');
+      gameEntry.ps1LauncherBoot = l.boot;
       gameEntry.isPs1Launcher = true;
-      gameEntry.appFolder = ps1Launcher!.folder;
-      gameEntry.ps1VmcSub = ps1Launcher!.folder.replace(/^POPS_/i, '');
+      gameEntry.appFolder = l.folder;
+      gameEntry.ps1VmcSub = l.folder.replace(/^POPS_/i, '');
     }
 
     return gameEntry;
@@ -586,7 +586,7 @@ export class LibraryService {
     gamefiles: RawGameFile[],
     ulGames: Game[] = [],
     apps: Game[] = [],
-    ps1LauncherMap?: Map<string, { folder: string; title: string; boot: string; path: string; gameId?: string }>
+    ps1LauncherMap?: Map<string, Ps1LauncherInfo>
   ) {
     this.setLoading(true);
     this.setCurrentAction('Mapping gamefiles to Game Objects...');

--- a/angular/src/app/shared/services/library.service.ts
+++ b/angular/src/app/shared/services/library.service.ts
@@ -829,7 +829,7 @@ export class LibraryService {
     }
   }
 
-  public async deleteGame(game: Game) {
+  public async deleteGame(game: Game, skipRefresh = false) {
     this._logger.log('deleteGame', `Deleting game: ${game.gameId} (${game.title})`);
     this.setLoading(true);
     this.setCurrentAction(`Deleting ${game.title || game.gameId}...`);
@@ -845,10 +845,13 @@ export class LibraryService {
 
       if (result.success) {
         this._logger.log('deleteGame', `Successfully deleted ${game.gameId}`);
-        this.refreshGamesFiles();
+        if (!skipRefresh) {
+          this.refreshGamesFiles();
+        }
       } else {
         this._logger.error('deleteGame', `Failed to delete: ${result.message}`);
       }
+      return result;
     } catch (error: any) {
       this._logger.error('deleteGame', `Error: ${error?.message || error}`);
     } finally {

--- a/angular/src/app/shared/services/library.service.ts
+++ b/angular/src/app/shared/services/library.service.ts
@@ -295,7 +295,7 @@ export class LibraryService {
             ps1LaunchersResult?.success && ps1LaunchersResult.launchers
               ? ps1LaunchersResult.launchers
               : [];
-          const ps1LauncherMap = new Map<string, { folder: string; title: string; boot: string; path: string }>();
+          const ps1LauncherMap = new Map<string, { folder: string; title: string; boot: string; path: string; gameId?: string }>();
           for (const launcher of ps1Launchers) {
             const name = launcher.folder.replace(/^POPS_/i, '');
             ps1LauncherMap.set(name.toLowerCase(), launcher);
@@ -484,7 +484,7 @@ export class LibraryService {
    */
   private async parseSingleFile(
     file: RawGameFile,
-    ps1LauncherMap?: Map<string, { folder: string; title: string; boot: string; path: string }>
+    ps1LauncherMap?: Map<string, { folder: string; title: string; boot: string; path: string; gameId?: string }>
   ): Promise<Game | null> {
     const gameIdMatch = file.name.match(/^([A-Z]{4}_\d{3}\.\d{2})\.(.+)$/i);
     const ext = file.extension?.toLowerCase();
@@ -501,7 +501,7 @@ export class LibraryService {
 
     let gameId: string;
     let title: string;
-    let ps1Launcher: { folder: string; title: string; boot: string; path: string } | undefined;
+    let ps1Launcher: { folder: string; title: string; boot: string; path: string; gameId?: string } | undefined;
 
     if (gameIdMatch) {
       gameId = gameIdMatch[1];
@@ -518,11 +518,17 @@ export class LibraryService {
     } else {
       this.setCurrentAction(`Resolving VCD ${file.name}…`);
       const resolved = await window.libraryAPI.tryDeterminePs1GameIdFromVcd(file.path);
-      if (!resolved?.success || !resolved.gameId) return null;
-      gameId = resolved.gameId;
-      title = resolved.gameName || file.name;
       if (ps1LauncherMap) {
         ps1Launcher = ps1LauncherMap.get(file.name.toLowerCase());
+      }
+      if (resolved?.success && resolved.gameId) {
+        gameId = resolved.gameId;
+        title = resolved.gameName || file.name;
+      } else if (ps1Launcher?.gameId) {
+        gameId = ps1Launcher.gameId;
+        title = file.name;
+      } else {
+        return null;
       }
     }
 
@@ -580,7 +586,7 @@ export class LibraryService {
     gamefiles: RawGameFile[],
     ulGames: Game[] = [],
     apps: Game[] = [],
-    ps1LauncherMap?: Map<string, { folder: string; title: string; boot: string; path: string }>
+    ps1LauncherMap?: Map<string, { folder: string; title: string; boot: string; path: string; gameId?: string }>
   ) {
     this.setLoading(true);
     this.setCurrentAction('Mapping gamefiles to Game Objects...');

--- a/angular/src/app/shared/services/library.service.ts
+++ b/angular/src/app/shared/services/library.service.ts
@@ -835,7 +835,9 @@ export class LibraryService {
     this.setCurrentAction(`Deleting ${game.title || game.gameId}...`);
 
     try {
-      const artDir = `${this.currentDirectory}/ART`;
+      const currentDir = this.currentDirectory ?? '';
+      const sep = currentDir.includes('\\') ? '\\' : '/';
+      const artDir = `${currentDir.replace(/[\\/]$/, '')}${sep}ART`;
       const result = await window.libraryAPI.deleteGameAndRelatedFiles(
         game.path,
         artDir,

--- a/angular/src/app/shared/services/library.service.ts
+++ b/angular/src/app/shared/services/library.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { LogsService } from './logs.service';
 import { SettingsService } from './settings.service';
 import { BehaviorSubject, map, Observable } from 'rxjs';
-import { Game, GameFormat, RawGameFile } from '../types/game.type';
+import { Game, GameFormat, RawGameFile, gameArt } from '../types/game.type';
 
 @Injectable({
   providedIn: 'root',
@@ -259,7 +259,8 @@ export class LibraryService {
         window.libraryAPI.getGamesFiles(currentDirectory),
         window.libraryAPI.getULGames(currentDirectory),
         window.libraryAPI.getApps(currentDirectory),
-      ]).then(async ([files, ulResult, appsResult]) => {
+        window.libraryAPI.getPs1Launchers(currentDirectory),
+      ]).then(async ([files, ulResult, appsResult, ps1LaunchersResult]) => {
         if (files.success) {
           this._logger.log(
             'libraryService',
@@ -289,7 +290,21 @@ export class LibraryService {
             this._logger.log('libraryService', `Found ${apps.length} app(s)`);
           }
 
-          await this.parseGameFilesToLibrary(files.data, ulGames, apps);
+          // Build PS1 launcher map: POPS_<sanitizedName> → launcher info
+          const ps1Launchers =
+            ps1LaunchersResult?.success && ps1LaunchersResult.launchers
+              ? ps1LaunchersResult.launchers
+              : [];
+          const ps1LauncherMap = new Map<string, { folder: string; title: string; boot: string; path: string }>();
+          for (const launcher of ps1Launchers) {
+            const name = launcher.folder.replace(/^POPS_/i, '');
+            ps1LauncherMap.set(name.toLowerCase(), launcher);
+          }
+          if (ps1Launchers.length > 0) {
+            this._logger.log('libraryService', `Found ${ps1Launchers.length} PS1 launcher(s) in APPS/POPS_*`);
+          }
+
+          await this.parseGameFilesToLibrary(files.data, ulGames, apps, ps1LauncherMap);
         } else {
           this._logger.error('libraryService', files.message);
           this.setCurrentAction('');
@@ -463,101 +478,137 @@ export class LibraryService {
     }));
   }
 
+  /**
+   * Resolve a single disc-image file to a Game with optional PS1 launcher link.
+   * Returns null if the file is invalid or its game ID can't be resolved.
+   */
+  private async parseSingleFile(
+    file: RawGameFile,
+    ps1LauncherMap?: Map<string, { folder: string; title: string; boot: string; path: string }>
+  ): Promise<Game | null> {
+    const gameIdMatch = file.name.match(/^([A-Z]{4}_\d{3}\.\d{2})\.(.+)$/i);
+    const ext = file.extension?.toLowerCase();
+    const looksLikeImage =
+      (ext === '.iso' || ext === '.zso' || ext === '.vcd') &&
+      typeof file.name === 'string' &&
+      typeof file.path === 'string' &&
+      !!file.stats &&
+      typeof file.stats.size === 'number';
+
+    if (!looksLikeImage) return null;
+
+    this.setCurrentAction(file.name);
+
+    let gameId: string;
+    let title: string;
+    let ps1Launcher: { folder: string; title: string; boot: string; path: string } | undefined;
+
+    if (gameIdMatch) {
+      gameId = gameIdMatch[1];
+      title = gameIdMatch[2];
+      if (ps1LauncherMap && ext === '.vcd') {
+        ps1Launcher = ps1LauncherMap.get(title.toLowerCase());
+      }
+    } else if (ext === '.iso' || ext === '.zso') {
+      this.setCurrentAction(`Resolving ${file.name}…`);
+      const resolved = await window.libraryAPI.resolveIsoGameId(file.path);
+      if (!resolved?.success || !resolved.gameId) return null;
+      gameId = resolved.gameId;
+      title = resolved.gameName || file.name;
+    } else {
+      this.setCurrentAction(`Resolving VCD ${file.name}…`);
+      const resolved = await window.libraryAPI.tryDeterminePs1GameIdFromVcd(file.path);
+      if (!resolved?.success || !resolved.gameId) return null;
+      gameId = resolved.gameId;
+      title = resolved.gameName || file.name;
+      if (ps1LauncherMap) {
+        ps1Launcher = ps1LauncherMap.get(file.name.toLowerCase());
+      }
+    }
+
+    const dirName = file.parentPath?.split(/[\\/]/).pop() || '';
+    const isPops = dirName === 'POPS';
+    const isVcd = dirName === 'VCD';
+    const hasLauncher = !!ps1Launcher && isPops;
+
+    const gameEntry: Game = {
+      filename: file.name + file.extension,
+      title,
+      cdType: hasLauncher ? 'APPS' : isPops ? 'POPS' : dirName,
+      gameId,
+      region: this.mapGameIdToRegion(gameId),
+      path: file.path,
+      extension: file.extension,
+      parentPath: file.parentPath,
+      format: isPops ? 'POPS' : this.extensionToFormat(file.extension),
+      system: hasLauncher ? 'APPS' : isPops || isVcd ? 'PS1' : 'PS2',
+      size: this.formatFileSize(file.stats!.size) || '??',
+    };
+
+    if (hasLauncher) {
+      gameEntry.title = ps1Launcher!.title;
+      gameEntry.ps1LauncherPath = ps1Launcher!.path.replace(/[\\/][^\\/]+\.elf$/i, '');
+      gameEntry.ps1LauncherBoot = ps1Launcher!.boot;
+      gameEntry.isPs1Launcher = true;
+      gameEntry.appFolder = ps1Launcher!.folder;
+      gameEntry.ps1VmcSub = ps1Launcher!.folder.replace(/^POPS_/i, '');
+    }
+
+    return gameEntry;
+  }
+
+  /**
+   * Match artwork from the /ART directory against every game in the list.
+   * PS1 launcher apps are matched by boot ELF name; all others by gameId.
+   */
+  private matchArtForGames(games: Game[], artFiles: gameArt[]): void {
+    for (const game of games) {
+      if (game.isPs1Launcher && game.ps1LauncherBoot) {
+        const bootName = game.ps1LauncherBoot;
+        game.art = artFiles.filter(
+          (art: gameArt) => art.name === bootName + '_' + (art.type || ''),
+        );
+      } else {
+        game.art = artFiles.filter(
+          (art: gameArt) => art.gameId === game.gameId,
+        );
+      }
+    }
+  }
+
   private async parseGameFilesToLibrary(
     gamefiles: RawGameFile[],
     ulGames: Game[] = [],
-    apps: Game[] = []
+    apps: Game[] = [],
+    ps1LauncherMap?: Map<string, { folder: string; title: string; boot: string; path: string }>
   ) {
     this.setLoading(true);
     this.setCurrentAction('Mapping gamefiles to Game Objects...');
     this._logger.verbose(
       'libraryService.parseGameFilesToLibrary',
-      'Started mapping gamefiles to GameObjects: ' +
-        gamefiles.length +
-        ' Files...'
+      `Started mapping gamefiles to GameObjects: ${gamefiles.length} Files...`
     );
     const validGames: Game[] = [];
-    const invalidFiles: any[] = [];
+    const invalidFiles: RawGameFile[] = [];
 
     for (const file of gamefiles) {
-      const gameIdMatch = file.name.match(/^([A-Z]{4}_\d{3}\.\d{2})\.(.+)$/i);
-      const ext = file.extension?.toLowerCase();
-      const looksLikeImage =
-        (ext === '.iso' || ext === '.zso' || ext === '.vcd') &&
-        typeof file.name === 'string' &&
-        typeof file.path === 'string' &&
-        !!file.stats &&
-        typeof file.stats.size === 'number';
-
-      if (!looksLikeImage) {
-        invalidFiles.push(file);
-        continue;
-      }
-
-      this.setLoading(true);
-      this.setCurrentAction(file.name);
       this._logger.verbose(
         'libraryService.parseGameFilesToLibrary',
         `Mapping: ${file.name}`
       );
-
-      let gameId: string;
-      let title: string;
-
-      if (gameIdMatch) {
-        // Legacy naming convention: GAMEID prefix in the filename.
-        gameId = gameIdMatch[1];
-        title = gameIdMatch[2];
-      } else if (ext === '.iso' || ext === '.zso') {
-        // "New" OPL naming convention: no GAMEID prefix — read the game ID from
-        // the disc image (ZSO is decompressed on the fly). Cached after the
-        // first scan.
-        this.setCurrentAction(`Resolving ${file.name}…`);
-        const resolved = await window.libraryAPI.resolveIsoGameId(file.path);
-        if (!resolved?.success || !resolved.gameId) {
-          invalidFiles.push(file);
-          continue;
-        }
-        gameId = resolved.gameId;
-        title = resolved.gameName || file.name;
+      const game = await this.parseSingleFile(file, ps1LauncherMap);
+      if (game) {
+        validGames.push(game);
       } else {
-        // .vcd without a GAMEID prefix isn't resolvable yet (would need VCD
-        // block decompression). Treat as invalid for now.
         invalidFiles.push(file);
-        continue;
       }
-
-      const dirName = file.parentPath?.split(/[\\/]/).pop() || '';
-      const isPops = dirName === 'POPS';
-      const isVcd = dirName === 'VCD';
-      const isPs1 = isPops || isVcd;
-
-      validGames.push({
-        filename: file.name + file.extension,
-        title: title,
-        cdType: isPops ? 'POPS' : dirName,
-        gameId: gameId,
-        region: this.mapGameIdToRegion(gameId),
-        path: file.path,
-        extension: file.extension,
-        parentPath: file.parentPath,
-        format: isPops ? 'POPS' : this.extensionToFormat(file.extension),
-        system: isPs1 ? 'PS1' : 'PS2',
-        size: this.formatFileSize(file.stats!.size) || '??',
-      });
     }
 
-    // Merge UL games and homebrew apps
-    validGames.push(...ulGames);
-    validGames.push(...apps);
+    validGames.push(...ulGames, ...apps);
 
     if (this.currentDirectory) {
       const artFiles = await this.parseArtFiles(this.currentDirectory);
-      for (const game of validGames) {
-        game.art = artFiles
-          .filter((art: any) => art.gameId === game.gameId)
-          .map((art: any) => art);
-      }
+      this.matchArtForGames(validGames, artFiles);
     }
 
     this.setLoading(true);
@@ -601,6 +652,15 @@ export class LibraryService {
     const currentLibrary = this.librarySubject.getValue();
     const updatedLibrary = currentLibrary.map((game) => {
       if (game.gameId === gameId) {
+        if (game.isPs1Launcher && game.ps1LauncherBoot) {
+          const bootName = game.ps1LauncherBoot;
+          return {
+            ...game,
+            art: artFiles
+              .filter((art: gameArt) => (bootName + '_' + (art.type || '')) === art.name)
+              .map((art: gameArt) => art),
+          };
+        }
         return {
           ...game,
           art: artFiles
@@ -611,6 +671,19 @@ export class LibraryService {
       return game;
     });
     this.librarySubject.next(updatedLibrary);
+
+    const updated = updatedLibrary.find((g) => g.gameId === gameId);
+    if (updated?.isPs1Launcher) {
+      this._logger.log(
+        'libraryService',
+        `updateArtForGame: PS1 launcher "${updated.title}" matched ${updated.art?.length ?? 0} art file(s) via boot name "${updated.ps1LauncherBoot}"`
+      );
+      if (updated.art?.length) {
+        for (const a of updated.art) {
+          this._logger.log('libraryService', `  art: ${a.name} (${a.path})`);
+        }
+      }
+    }
   }
 
   public tryDetermineGameIdFromHex(filepath: string) {
@@ -760,7 +833,8 @@ export class LibraryService {
       const result = await window.libraryAPI.deleteGameAndRelatedFiles(
         game.path,
         artDir,
-        game.gameId
+        game.gameId,
+        game.appFolder
       );
 
       if (result.success) {

--- a/angular/src/app/shared/services/vmc.service.ts
+++ b/angular/src/app/shared/services/vmc.service.ts
@@ -22,7 +22,7 @@ export class VmcService {
 
   constructor(
     private readonly _library: LibraryService,
-    private readonly _logger: LogsService
+    private readonly _logger: LogsService,
   ) {}
 
   public get cards(): VmcInfo[] {
@@ -44,7 +44,31 @@ export class VmcService {
     return res.cards;
   }
 
-  async create(name: string, sizeMb: number): Promise<{ ok: boolean; name?: string; message?: string }> {
+  /**
+   * Check per-game POPS VMC files for a PS1 launcher app.
+   * Returns whether SLOT0.VMC and SLOT1.VMC exist in VMC/POPS/<gameTitle>/.
+   * Does NOT update cardsSubject (these are per-game, not global cards).
+   */
+  async checkPops(
+    gameTitle: string,
+  ): Promise<{ slot0: string | null; slot1: string | null }> {
+    const root = this._library.currentDirectoryValue;
+    if (!root) return { slot0: null, slot1: null };
+    const res = await window.libraryAPI.checkPopsVmc(root, gameTitle);
+    if (!res.success) {
+      this._logger.error(
+        'vmcService',
+        `Failed to check POPS VMC for "${gameTitle}"`,
+      );
+      return { slot0: null, slot1: null };
+    }
+    return { slot0: res.slot0, slot1: res.slot1 };
+  }
+
+  async create(
+    name: string,
+    sizeMb: number,
+  ): Promise<{ ok: boolean; name?: string; message?: string }> {
     const root = this._library.currentDirectoryValue;
     if (!root) return { ok: false, message: 'No directory mounted.' };
     const res = await window.libraryAPI.createVmc(root, name, sizeMb);

--- a/angular/src/app/shared/types/game.type.ts
+++ b/angular/src/app/shared/types/game.type.ts
@@ -15,6 +15,14 @@ export type Game = {
   art?: gameArt[];
   /** APPS only: the subfolder name under APPS/ (used for deletion). */
   appFolder?: string;
+  /** PS1 only: path to the APPS/POPS_* launcher folder for this game. */
+  ps1LauncherPath?: string;
+  /** PS1 only: ELF boot filename inside the launcher folder. */
+  ps1LauncherBoot?: string;
+  /** PS1 only: POPS subfolder for VMC detection (derived from POPS_ prefix). */
+  ps1VmcSub?: string;
+  /** Marks this APPS entry as a PS1 POPStarter launcher (OPL 1.2+). */
+  isPs1Launcher?: boolean;
 };
 
 export type RawGameFile = {

--- a/angular/src/app/shared/types/game.type.ts
+++ b/angular/src/app/shared/types/game.type.ts
@@ -1,5 +1,13 @@
 export type GameFormat = 'ISO' | 'ZSO' | 'VCD' | 'UL' | 'POPS' | 'APP';
 
+export type Ps1LauncherInfo = {
+  folder: string;
+  title: string;
+  boot: string;
+  path: string;
+  gameId?: string;
+};
+
 export type Game = {
   filename: string;
   size?: string;

--- a/angular/src/app/window.d.ts
+++ b/angular/src/app/window.d.ts
@@ -120,6 +120,7 @@ declare interface Window {
         boot: string;
         path: string;
         sizeBytes: number;
+        gameId?: string;
       }[];
       message?: string;
     }>;

--- a/angular/src/app/window.d.ts
+++ b/angular/src/app/window.d.ts
@@ -127,6 +127,7 @@ declare interface Window {
     updatePs1TitleCfg: (
       launcherPath: string,
       newTitle: string,
+      gameId?: string,
     ) => Promise<{ success: boolean; message?: string }>;
     openAskElfFiles: () => Promise<any>;
     importApp: (

--- a/angular/src/app/window.d.ts
+++ b/angular/src/app/window.d.ts
@@ -197,6 +197,7 @@ declare interface Window {
       artDir: string,
       gameId: string,
       launcherFolder?: string,
+      bootName?: string,
     ) => Promise<any>;
     moveFile: (sourcePath: string, destPath: string) => Promise<any>;
     onMoveFileProgress: (

--- a/angular/src/app/window.d.ts
+++ b/angular/src/app/window.d.ts
@@ -148,6 +148,15 @@ declare interface Window {
       oplRoot: string,
       folder: string,
     ) => Promise<{ success: boolean; message?: string }>;
+    deleteAppWithProgress: (
+      oplRoot: string,
+      folder: string,
+      bootName: string,
+    ) => Promise<{ success: boolean; entries: Array<{ label: string; path?: string; success: boolean; error?: string }> }>;
+    onDeleteAppProgress: (
+      callback: (entry: { label: string; path?: string; success: boolean; error?: string }) => void,
+    ) => void;
+    removeAllDeleteAppProgressListeners: () => void;
     listVmc: (oplRoot: string) => Promise<{
       success: boolean;
       cards: { name: string; sizeBytes: number; sizeMb: number }[];

--- a/angular/src/app/window.d.ts
+++ b/angular/src/app/window.d.ts
@@ -45,6 +45,15 @@ declare interface Window {
       callback: (progress: { percent: number; stage: string }) => void,
     ) => void;
     removeAllRenamePs1ProgressListeners: () => void;
+    onDeletePs1Progress: (
+      callback: (entry: {
+        label: string;
+        path?: string;
+        success: boolean;
+        error?: string;
+      }) => void,
+    ) => void;
+    removeAllDeletePs1ProgressListeners: () => void;
     downloadArtByGameId: (
       dirPath: string,
       gameId: string,

--- a/angular/src/app/window.d.ts
+++ b/angular/src/app/window.d.ts
@@ -151,7 +151,7 @@ declare interface Window {
     deleteAppWithProgress: (
       oplRoot: string,
       folder: string,
-      bootName: string,
+      bootName?: string,
     ) => Promise<{ success: boolean; entries: Array<{ label: string; path?: string; success: boolean; error?: string }> }>;
     onDeleteAppProgress: (
       callback: (entry: { label: string; path?: string; success: boolean; error?: string }) => void,
@@ -198,7 +198,11 @@ declare interface Window {
       gameId: string,
       launcherFolder?: string,
       bootName?: string,
-    ) => Promise<any>;
+    ) => Promise<{
+      success: boolean;
+      entries: Array<{ label: string; path?: string; success: boolean; error?: string }>;
+      message?: string;
+    }>;
     moveFile: (sourcePath: string, destPath: string) => Promise<any>;
     onMoveFileProgress: (
       callback: (progress: {

--- a/angular/src/app/window.d.ts
+++ b/angular/src/app/window.d.ts
@@ -20,6 +20,31 @@ declare interface Window {
       gameName: string,
       nameOnly?: boolean,
     ) => Promise<any>;
+    renamePs1LauncherStep1: (
+      vcdPath: string,
+      gameId: string,
+      newTitle: string,
+    ) => Promise<{
+      success: boolean;
+      newVcdPath?: string;
+      oldElfFile?: string;
+      newElfFile?: string;
+      newCfgContent?: string;
+      newAppsFolder?: string;
+      safeNewTitle?: string;
+      message?: string;
+    }>;
+    renamePs1LauncherStep2: (params: {
+      newAppsFolder: string;
+      oldElfFile?: string;
+      newElfFile?: string;
+      newCfgContent?: string;
+      newTitle: string;
+    }) => Promise<{ success: boolean; message?: string }>;
+    onRenamePs1Progress: (
+      callback: (progress: { percent: number; stage: string }) => void,
+    ) => void;
+    removeAllRenamePs1ProgressListeners: () => void;
     downloadArtByGameId: (
       dirPath: string,
       gameId: string,
@@ -98,6 +123,10 @@ declare interface Window {
       }[];
       message?: string;
     }>;
+    updatePs1TitleCfg: (
+      launcherPath: string,
+      newTitle: string,
+    ) => Promise<{ success: boolean; message?: string }>;
     openAskElfFiles: () => Promise<any>;
     importApp: (
       oplRoot: string,

--- a/angular/src/app/window.d.ts
+++ b/angular/src/app/window.d.ts
@@ -10,7 +10,7 @@ declare interface Window {
     }>;
     createOplFolders: (
       dirPath: string,
-      folders: string[]
+      folders: string[],
     ) => Promise<{ success: boolean; created?: string[]; message?: string }>;
     getULGames: (dirPath: string) => Promise<any>;
     getArtFolder: (dirPath: string) => Promise<any>;
@@ -18,13 +18,18 @@ declare interface Window {
       dirPath: string,
       gameId: string,
       gameName: string,
-      nameOnly?: boolean
+      nameOnly?: boolean,
     ) => Promise<any>;
     downloadArtByGameId: (
       dirPath: string,
       gameId: string,
-      system?: 'PS1' | 'PS2'
+      system?: 'PS1' | 'PS2',
+      saveAsName?: string,
     ) => Promise<any>;
+    checkArtFilesExist: (
+      artDir: string,
+      filenames: string[],
+    ) => Promise<string[]>;
     tryDetermineGameIdFromHex: (filepath: string) => Promise<any>;
     resolveIsoGameId: (filepath: string) => Promise<{
       success: boolean;
@@ -34,14 +39,21 @@ declare interface Window {
     }>;
     openAskGameFiles: (isGameCd: boolean, isGameDvd: boolean) => Promise<any>;
     tryDeterminePs1GameIdFromHex: (filepath: string) => Promise<any>;
+    tryDeterminePs1GameIdFromVcd: (filepath: string) => Promise<{
+      success: boolean;
+      gameId?: string;
+      formattedGameId?: string;
+      gameName?: string;
+      message?: string;
+    }>;
     importPs1Game: (
       cueFilePath: string,
       oplRoot: string,
       elfPrefix: string,
-      downloadArtwork: boolean
+      downloadArtwork: boolean,
     ) => Promise<any>;
     onPs1ImportProgress: (
-      callback: (progress: { percent: number; stage: string }) => void
+      callback: (progress: { percent: number; stage: string }) => void,
     ) => void;
     removeAllPs1ImportProgressListeners: () => void;
     importPs2CdGame: (
@@ -49,19 +61,19 @@ declare interface Window {
       oplRoot: string,
       gameId: string | undefined,
       gameName: string | undefined,
-      downloadArtwork: boolean
+      downloadArtwork: boolean,
     ) => Promise<any>;
     onPs2CdImportProgress: (
-      callback: (progress: { percent: number; stage: string }) => void
+      callback: (progress: { percent: number; stage: string }) => void,
     ) => void;
     removeAllPs2CdImportProgressListeners: () => void;
     compressIsoToZso: (
       isoPath: string,
       zsoPath: string,
-      deleteOriginal: boolean
+      deleteOriginal: boolean,
     ) => Promise<any>;
     onZsoCompressProgress: (
-      callback: (progress: { percent: number; stage: string }) => void
+      callback: (progress: { percent: number; stage: string }) => void,
     ) => void;
     removeAllZsoCompressProgressListeners: () => void;
     getApps: (oplRoot: string) => Promise<{
@@ -75,33 +87,52 @@ declare interface Window {
       }[];
       message?: string;
     }>;
+    getPs1Launchers: (oplRoot: string) => Promise<{
+      success: boolean;
+      launchers: {
+        folder: string;
+        title: string;
+        boot: string;
+        path: string;
+        sizeBytes: number;
+      }[];
+      message?: string;
+    }>;
     openAskElfFiles: () => Promise<any>;
     importApp: (
       oplRoot: string,
       elfPath: string,
-      title: string
+      title: string,
     ) => Promise<{ success: boolean; folder?: string; message?: string }>;
     deleteApp: (
       oplRoot: string,
-      folder: string
+      folder: string,
     ) => Promise<{ success: boolean; message?: string }>;
     listVmc: (oplRoot: string) => Promise<{
       success: boolean;
       cards: { name: string; sizeBytes: number; sizeMb: number }[];
       message?: string;
     }>;
+    checkPopsVmc: (
+      oplRoot: string,
+      gameTitle: string,
+    ) => Promise<{
+      success: boolean;
+      slot0: string | null;
+      slot1: string | null;
+    }>;
     createVmc: (
       oplRoot: string,
       name: string,
-      sizeMb: number
+      sizeMb: number,
     ) => Promise<{ success: boolean; name?: string; message?: string }>;
     deleteVmc: (
       oplRoot: string,
-      name: string
+      name: string,
     ) => Promise<{ success: boolean; message?: string }>;
     readGameCfg: (
       oplRoot: string,
-      gameId: string
+      gameId: string,
     ) => Promise<{
       success: boolean;
       entries: Record<string, string>;
@@ -110,12 +141,13 @@ declare interface Window {
     writeGameCfg: (
       oplRoot: string,
       gameId: string,
-      entries: Record<string, string>
+      entries: Record<string, string>,
     ) => Promise<{ success: boolean; message?: string }>;
     deleteGameAndRelatedFiles: (
       gamePath: string,
       artDir: string,
-      gameId: string
+      gameId: string,
+      launcherFolder?: string,
     ) => Promise<any>;
     moveFile: (sourcePath: string, destPath: string) => Promise<any>;
     onMoveFileProgress: (
@@ -124,7 +156,7 @@ declare interface Window {
         copiedMB: number;
         totalMB: number;
         elapsed: number;
-      }) => void
+      }) => void,
     ) => void;
     removeAllMoveFileProgressListeners: () => void;
     onMainLog: (
@@ -133,14 +165,14 @@ declare interface Window {
         location?: string;
         message: string;
         timestamp: string;
-      }) => void
+      }) => void,
     ) => void;
     removeAllMainLogListeners: () => void;
     setLoadingState: (isLoading: boolean) => void;
     getSettings: () => Promise<AppSettings>;
     setSetting: <K extends keyof AppSettings>(
       key: K,
-      value: AppSettings[K]
+      value: AppSettings[K],
     ) => Promise<AppSettings>;
     directoryExists: (dirPath: string) => Promise<boolean>;
     checkForUpdates: () => Promise<UpdateCheckResult>;

--- a/angular/tsconfig.json
+++ b/angular/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "compileOnSave": false,
   "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@shared/*": ["src/app/shared/*"]
+    },
     "outDir": "./dist/out-tsc",
     "strict": true,
     "noImplicitOverride": true,

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:watch": "tsc -w",
     "build:info": "node scripts/generate-build-info.js",
     "app:serve": "npm run build:info && concurrently \"npm run angular:serve\" \"npm run build:watch\" \"wait-on http://localhost:4200 && npm run electron:serve\"",
-    "angular:serve": "cd angular && ng serve",
+    "angular:serve": "cd angular && npx ng serve",
     "electron:serve": "electron ./dist/src/main.js --serve",
     "start": "npm run build:info && npm run build && electron ./dist/src/main.js",
     "package:win": "npm run remove && npm run build:info && cd angular && npm run build --omit=dev && cd .. && npm run build && electron-builder --win",

--- a/src/apps.service.ts
+++ b/src/apps.service.ts
@@ -237,7 +237,12 @@ export async function deleteApp(
       log.warn(`Rejected app delete for suspicious folder name: "${folder}"`);
       return { success: false, message: "Invalid app folder." };
     }
-    await fs.rm(path.join(appsDir(oplRoot), folder), {
+    const target = path.resolve(appsDir(oplRoot), folder);
+    if (!target.startsWith(appsDir(oplRoot) + path.sep)) {
+      log.warn(`Path traversal blocked for app folder: "${folder}"`);
+      return { success: false, message: "Invalid app folder." };
+    }
+    await fs.rm(target, {
       recursive: true,
       force: true,
     });

--- a/src/apps.service.ts
+++ b/src/apps.service.ts
@@ -20,6 +20,8 @@ export interface AppInfo {
   /** Absolute path to the boot ELF, when it exists. */
   path: string;
   sizeBytes: number;
+  /** Optional PS1 game ID from title.cfg GameID= attribute. */
+  gameId?: string;
 }
 
 function appsDir(oplRoot: string): string {
@@ -37,8 +39,8 @@ function sanitizeAppName(name: string): string {
   );
 }
 
-function parseTitleCfg(raw: string): { title?: string; boot?: string } {
-  const out: { title?: string; boot?: string } = {};
+function parseTitleCfg(raw: string): { title?: string; boot?: string; gameId?: string } {
+  const out: { title?: string; boot?: string; gameId?: string } = {};
   for (const line of raw.split(/\r?\n/)) {
     const eq = line.indexOf("=");
     if (eq <= 0) continue;
@@ -46,6 +48,7 @@ function parseTitleCfg(raw: string): { title?: string; boot?: string } {
     const val = line.slice(eq + 1).trim();
     if (key === "title") out.title = val;
     else if (key === "boot") out.boot = val;
+    else if (key === "gameid") out.gameId = val;
   }
   return out;
 }
@@ -69,12 +72,14 @@ async function enumerateApps(
 
     let title = item.name;
     let boot = "";
+    let gameId: string | undefined;
     try {
       const cfg = parseTitleCfg(
         await fs.readFile(path.join(folderPath, "title.cfg"), "utf-8")
       );
       if (cfg.title) title = cfg.title;
       if (cfg.boot) boot = cfg.boot;
+      if (cfg.gameId) gameId = cfg.gameId;
     } catch {
       // No title.cfg — fall back to the first ELF in the folder.
     }
@@ -95,7 +100,7 @@ async function enumerateApps(
       continue;
     }
 
-    apps.push({ folder: item.name, title, boot, path: elfPath, sizeBytes });
+    apps.push({ folder: item.name, title, boot, path: elfPath, sizeBytes, gameId });
   }
 
   apps.sort((a, b) => a.title.localeCompare(b.title));

--- a/src/apps.service.ts
+++ b/src/apps.service.ts
@@ -173,6 +173,54 @@ export async function importApp(
   }
 }
 
+/**
+ * Updates the `title=` / `Title=` lines in a PS1 launcher's `title.cfg`,
+ * preserving the original key casing. Adds both lines if neither exists.
+ * Creates a new `title.cfg` if one does not exist.
+ */
+export async function updatePs1TitleCfg(
+  launcherPath: string,
+  newTitle: string,
+): Promise<{ success: boolean; message?: string }> {
+  try {
+    const cfgPath = path.join(launcherPath, "title.cfg");
+    let oldContent: string;
+    try {
+      oldContent = await fs.readFile(cfgPath, "utf-8");
+    } catch {
+      await fs.writeFile(cfgPath, `title=${newTitle}\nTitle=${newTitle}\n`, "utf-8");
+      log.info(`Created title.cfg for ${path.basename(launcherPath)}`);
+      return { success: true };
+    }
+
+    const seenKeys = new Map<string, string>();
+    const cfgLines = oldContent.split("\n").map((line) => {
+      const t = line.trimEnd();
+      const eq = t.indexOf("=");
+      if (eq === -1) return line;
+      const k = t.slice(0, eq).trim();
+      const lower = k.toLowerCase();
+      if (!seenKeys.has(lower)) seenKeys.set(lower, k);
+      if (lower === "title") {
+        return k === "Title" ? `Title=${newTitle}` : `title=${newTitle}`;
+      }
+      return line;
+    });
+
+    if (!seenKeys.has("title")) {
+      cfgLines.push(`title=${newTitle}`);
+      cfgLines.push(`Title=${newTitle}`);
+    }
+
+    await fs.writeFile(cfgPath, cfgLines.join("\n"), "utf-8");
+    log.info(`Updated title.cfg for ${path.basename(launcherPath)}`);
+    return { success: true };
+  } catch (err: any) {
+    log.error(`Failed to update title.cfg:`, err?.message || err);
+    return { success: false, message: err?.message || String(err) };
+  }
+}
+
 export async function deleteApp(
   oplRoot: string,
   folder: string

--- a/src/apps.service.ts
+++ b/src/apps.service.ts
@@ -50,55 +50,88 @@ function parseTitleCfg(raw: string): { title?: string; boot?: string } {
   return out;
 }
 
+/**
+ * Shared enumeration for APPS subfolders, filtered by `match`.
+ * Returns {@link AppInfo} for every subfolder matching the predicate.
+ */
+async function enumerateApps(
+  oplRoot: string,
+  match: (name: string) => boolean,
+): Promise<AppInfo[]> {
+  const dir = appsDir(oplRoot);
+  const items = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
+  const apps: AppInfo[] = [];
+
+  for (const item of items) {
+    if (!item.isDirectory()) continue;
+    if (!match(item.name)) continue;
+    const folderPath = path.join(dir, item.name);
+
+    let title = item.name;
+    let boot = "";
+    try {
+      const cfg = parseTitleCfg(
+        await fs.readFile(path.join(folderPath, "title.cfg"), "utf-8")
+      );
+      if (cfg.title) title = cfg.title;
+      if (cfg.boot) boot = cfg.boot;
+    } catch {
+      // No title.cfg — fall back to the first ELF in the folder.
+    }
+
+    if (!boot) {
+      const elf = (await fs.readdir(folderPath).catch(() => [])).find((f) =>
+        /\.elf$/i.test(f)
+      );
+      if (!elf) continue;
+      boot = elf;
+    }
+
+    const elfPath = path.join(folderPath, boot);
+    let sizeBytes = 0;
+    try {
+      sizeBytes = (await fs.stat(elfPath)).size;
+    } catch {
+      continue;
+    }
+
+    apps.push({ folder: item.name, title, boot, path: elfPath, sizeBytes });
+  }
+
+  apps.sort((a, b) => a.title.localeCompare(b.title));
+  return apps;
+}
+
+/**
+ * Returns PS1 POPStarter launchers from the APPS folder.
+ *
+ * These are the APPS/POPS_* folders normally skipped by getApps() — they
+ * correspond to PS1 VCD files in POPS/ and carry the POPStarter ELF along
+ * with the game title. The caller pairs them with VCD files to build proper
+ * PS1 game entries.
+ */
+export async function getPs1Launchers(
+  oplRoot: string
+): Promise<{ success: boolean; launchers: AppInfo[]; message?: string }> {
+  try {
+    const launchers = await enumerateApps(oplRoot, (name) => /^POPS_/i.test(name));
+    log.verbose(`Found ${launchers.length} PS1 POPStarter launcher(s) in APPS/POPS_*`);
+    return { success: true, launchers };
+  } catch (err: any) {
+    log.error(`Failed to enumerate PS1 launchers:`, err?.message || err);
+    return { success: false, launchers: [], message: err?.message || String(err) };
+  }
+}
+
 export async function getApps(
   oplRoot: string
 ): Promise<{ success: boolean; apps: AppInfo[]; message?: string }> {
   try {
-    const dir = appsDir(oplRoot);
-    const items = await fs.readdir(dir, { withFileTypes: true }).catch(() => []);
-    const apps: AppInfo[] = [];
-
-    for (const item of items) {
-      if (!item.isDirectory()) continue;
-      // Skip POPStarter launchers for PS1 games — those folders are created
-      // alongside each PS1 VCD and are already represented by their PS1 entry
-      // in the library. Showing them here would duplicate every PS1 title.
-      if (/^POPS_/i.test(item.name)) continue;
-      const folderPath = path.join(dir, item.name);
-
-      let title = item.name;
-      let boot = "";
-      try {
-        const cfg = parseTitleCfg(
-          await fs.readFile(path.join(folderPath, "title.cfg"), "utf-8")
-        );
-        if (cfg.title) title = cfg.title;
-        if (cfg.boot) boot = cfg.boot;
-      } catch {
-        // No title.cfg — fall back to the first ELF in the folder.
-      }
-
-      if (!boot) {
-        const elf = (await fs.readdir(folderPath).catch(() => [])).find((f) =>
-          /\.elf$/i.test(f)
-        );
-        if (!elf) continue; // not a launchable app folder
-        boot = elf;
-      }
-
-      const elfPath = path.join(folderPath, boot);
-      let sizeBytes = 0;
-      try {
-        sizeBytes = (await fs.stat(elfPath)).size;
-      } catch {
-        continue; // boot target missing — skip
-      }
-
-      apps.push({ folder: item.name, title, boot, path: elfPath, sizeBytes });
-    }
-
-    apps.sort((a, b) => a.title.localeCompare(b.title));
-    log.verbose(`Found ${apps.length} homebrew app(s) in ${dir}`);
+    // Skip POPStarter launchers for PS1 games — those folders are created
+    // alongside each PS1 VCD and are already represented by their PS1 entry
+    // in the library. Showing them here would duplicate every PS1 title.
+    const apps = await enumerateApps(oplRoot, (name) => !/^POPS_/i.test(name));
+    log.verbose(`Found ${apps.length} homebrew app(s) in ${appsDir(oplRoot)}`);
     return { success: true, apps };
   } catch (err: any) {
     log.error(`Failed to enumerate apps in ${appsDir(oplRoot)}:`, err?.message || err);

--- a/src/apps.service.ts
+++ b/src/apps.service.ts
@@ -343,28 +343,30 @@ export async function deleteAppWithProgress(
       addEntry("App folder", false, rel(target), err?.message || String(err));
     }
 
-    // Delete ART files matching the boot ELF name
-    const artDir = path.join(oplRoot, "ART");
-    try {
-      const artFiles = await fs.readdir(artDir);
-      const matchingArt = artFiles.filter((f) =>
-        f.startsWith(bootName + "_")
-      );
-      if (matchingArt.length === 0) {
-        addEntry("Artwork", true, "None found");
-      } else {
-        for (const artFile of matchingArt) {
-          const artPath = path.join(artDir, artFile);
-          try {
-            await fs.unlink(artPath);
-            addEntry("Artwork", true, rel(artPath));
-          } catch (err: any) {
-            addEntry("Artwork", false, rel(artPath), err?.message || String(err));
+    // Delete ART files matching the boot ELF name (only when user opted in)
+    if (bootName) {
+      const artDir = path.join(oplRoot, "ART");
+      try {
+        const artFiles = await fs.readdir(artDir);
+        const matchingArt = artFiles.filter((f) =>
+          f.startsWith(bootName + "_")
+        );
+        if (matchingArt.length === 0) {
+          addEntry("Artwork", true, "None found");
+        } else {
+          for (const artFile of matchingArt) {
+            const artPath = path.join(artDir, artFile);
+            try {
+              await fs.unlink(artPath);
+              addEntry("Artwork", true, rel(artPath));
+            } catch (err: any) {
+              addEntry("Artwork", false, rel(artPath), err?.message || String(err));
+            }
           }
         }
+      } catch {
+        addEntry("Artwork", true, "No artwork directory");
       }
-    } catch {
-      addEntry("Artwork", true, "No artwork directory");
     }
 
     log.info(`Deleted app APPS/${folder} (${allFiles.length} file(s))`);

--- a/src/apps.service.ts
+++ b/src/apps.service.ts
@@ -186,6 +186,7 @@ export async function importApp(
 export async function updatePs1TitleCfg(
   launcherPath: string,
   newTitle: string,
+  gameId?: string,
 ): Promise<{ success: boolean; message?: string }> {
   try {
     const cfgPath = path.join(launcherPath, "title.cfg");
@@ -193,7 +194,7 @@ export async function updatePs1TitleCfg(
     try {
       oldContent = await fs.readFile(cfgPath, "utf-8");
     } catch {
-      await fs.writeFile(cfgPath, `title=${newTitle}\nTitle=${newTitle}\n`, "utf-8");
+      await fs.writeFile(cfgPath, `title=${newTitle}\nTitle=${newTitle}\n${gameId ? `GameID=${gameId}\n` : ''}`, "utf-8");
       log.info(`Created title.cfg for ${path.basename(launcherPath)}`);
       return { success: true };
     }

--- a/src/apps.service.ts
+++ b/src/apps.service.ts
@@ -253,3 +253,126 @@ export async function deleteApp(
     return { success: false, message: err?.message || String(err) };
   }
 }
+
+export interface DeleteAppEntry {
+  label: string;
+  path?: string;
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Delete an app folder with per-file progress reporting and optional ART cleanup.
+ * Reports each deleted file via `onProgress` and returns the full entry list.
+ */
+export async function deleteAppWithProgress(
+  oplRoot: string,
+  folder: string,
+  bootName: string,
+  onProgress?: (entry: DeleteAppEntry) => void
+): Promise<{ success: boolean; entries: DeleteAppEntry[] }> {
+  const entries: DeleteAppEntry[] = [];
+  const addEntry = (label: string, success: boolean, path?: string, error?: string) => {
+    const entry: DeleteAppEntry = { label, path, success, error };
+    entries.push(entry);
+    if (onProgress) onProgress(entry);
+  };
+
+  const rel = (p: string) => path.relative(oplRoot, p);
+
+  try {
+    // Guard against path traversal
+    if (!folder || folder.includes("/") || folder.includes("\\") || folder.includes("..")) {
+      addEntry("App folder", false, folder, "Invalid app folder.");
+      log.warn(`Rejected app delete for suspicious folder name: "${folder}"`);
+      return { success: false, entries };
+    }
+    const target = path.resolve(appsDir(oplRoot), folder);
+    if (!target.startsWith(appsDir(oplRoot) + path.sep)) {
+      addEntry("App folder", false, folder, "Path traversal blocked");
+      log.warn(`Path traversal blocked for app folder: "${folder}"`);
+      return { success: false, entries };
+    }
+
+    // Recursively collect all files and folders
+    const allFiles: string[] = [];
+    const allDirs: string[] = [];
+    const collect = async (dir: string) => {
+      const items = await fs.readdir(dir, { withFileTypes: true });
+      for (const item of items) {
+        const fullPath = path.join(dir, item.name);
+        if (item.isDirectory()) {
+          allDirs.push(fullPath);
+          await collect(fullPath);
+        } else {
+          allFiles.push(fullPath);
+        }
+      }
+    };
+    await collect(target);
+
+    // Delete files (deepest first)
+    for (const filePath of allFiles) {
+      const label = path.basename(filePath).toLowerCase() === "title.cfg"
+        ? "CONFIG FILE"
+        : "App file";
+      try {
+        await fs.unlink(filePath);
+        addEntry(label, true, rel(filePath));
+      } catch (err: any) {
+        addEntry(label, false, rel(filePath), err?.message || String(err));
+      }
+    }
+
+    // Delete subdirectories (reverse order = deepest first)
+    allDirs.reverse();
+    for (const dirPath of allDirs) {
+      try {
+        await fs.rmdir(dirPath);
+        addEntry("App folder", true, rel(dirPath));
+      } catch (err: any) {
+        addEntry("App folder", false, rel(dirPath), err?.message || String(err));
+      }
+    }
+
+    // Delete the top-level app folder
+    try {
+      await fs.rmdir(target);
+      addEntry("App folder", true, rel(target));
+    } catch (err: any) {
+      addEntry("App folder", false, rel(target), err?.message || String(err));
+    }
+
+    // Delete ART files matching the boot ELF name
+    const artDir = path.join(oplRoot, "ART");
+    try {
+      const artFiles = await fs.readdir(artDir);
+      const matchingArt = artFiles.filter((f) =>
+        f.startsWith(bootName + "_")
+      );
+      if (matchingArt.length === 0) {
+        addEntry("Artwork", true, "None found");
+      } else {
+        for (const artFile of matchingArt) {
+          const artPath = path.join(artDir, artFile);
+          try {
+            await fs.unlink(artPath);
+            addEntry("Artwork", true, rel(artPath));
+          } catch (err: any) {
+            addEntry("Artwork", false, rel(artPath), err?.message || String(err));
+          }
+        }
+      }
+    } catch {
+      addEntry("Artwork", true, "No artwork directory");
+    }
+
+    log.info(`Deleted app APPS/${folder} (${allFiles.length} file(s))`);
+    const allSuccess = entries.every((e) => e.success);
+    return { success: allSuccess, entries };
+  } catch (err: any) {
+    log.error(`Failed to delete app APPS/${folder}:`, err?.message || err);
+    addEntry("App folder", false, folder, err?.message || String(err));
+    return { success: false, entries };
+  }
+}

--- a/src/apps.service.ts
+++ b/src/apps.service.ts
@@ -268,7 +268,7 @@ export interface DeleteAppEntry {
 export async function deleteAppWithProgress(
   oplRoot: string,
   folder: string,
-  bootName: string,
+  bootName?: string,
   onProgress?: (entry: DeleteAppEntry) => void
 ): Promise<{ success: boolean; entries: DeleteAppEntry[] }> {
   const entries: DeleteAppEntry[] = [];

--- a/src/library.service.ts
+++ b/src/library.service.ts
@@ -619,6 +619,248 @@ export async function renameGamefile(
   }
 }
 
+export async function renamePs1LauncherStep1(
+  vcdPath: string,
+  gameId: string,
+  newTitle: string,
+  onProgress?: (percent: number, stage: string) => void
+): Promise<{
+  success: boolean;
+  newVcdPath?: string;
+  oldElfFile?: string;
+  newElfFile?: string;
+  newCfgContent?: string;
+  newAppsFolder?: string;
+  safeNewTitle?: string;
+  message?: string;
+}> {
+  const safeNewTitle = sanitizeGameFilename(newTitle);
+  if (!safeNewTitle) {
+    return { success: false, message: "The new name is empty or invalid after sanitization." };
+  }
+
+  const popsDir = path.dirname(vcdPath);
+  const oplRoot = path.resolve(popsDir, "..");
+  const vcdBasename = path.basename(vcdPath);
+  const vcdExt = path.extname(vcdBasename);
+  const vcdStem = vcdBasename.slice(0, -vcdExt.length);
+  const prefix = `${gameId}.`;
+  const oldTitle = vcdStem.startsWith(prefix) ? vcdStem.slice(prefix.length) : vcdStem;
+
+  if (!oldTitle) {
+    return { success: false, message: "Could not derive the current game title from the VCD filename." };
+  }
+  if (oldTitle === safeNewTitle) {
+    return { success: false, message: "The new name is identical to the current name." };
+  }
+
+  log.info(`PS1 rename step 1: "${oldTitle}" → "${safeNewTitle}" (gameId=${gameId})`);
+
+  const newVcdBasename = `${safeNewTitle}${vcdExt}`;
+  const newVcdPath = path.join(popsDir, newVcdBasename);
+  const appsDir = path.join(oplRoot, "APPS");
+  const oldAppsFolder = path.join(appsDir, `POPS_${oldTitle}`);
+  const newAppsFolder = path.join(appsDir, `POPS_${safeNewTitle}`);
+
+  // ── Rename the VCD file ─────────────────────────────────────────────
+  onProgress?.(15, `Renaming VCD: ${vcdBasename} → ${newVcdBasename}`);
+  try {
+    await fs.rename(vcdPath, newVcdPath);
+    log.verbose(`VCD renamed: ${vcdBasename} → ${newVcdBasename}`);
+  } catch (err: any) {
+    log.error(`Failed to rename VCD: ${err?.message || err}`);
+    return { success: false, message: `Failed to rename VCD: ${err?.message || err}` };
+  }
+
+  // ── Rename POPS VMC subfolder (if exists) ───────────────────────────
+  onProgress?.(25, `Renaming VMC folder: ${oldTitle}/ → ${safeNewTitle}/`);
+  try {
+    await fs.access(path.join(popsDir, oldTitle));
+    await fs.rename(path.join(popsDir, oldTitle), path.join(popsDir, safeNewTitle));
+    log.verbose(`POPS VMC subfolder renamed`);
+  } catch { /* doesn't exist — fine */ }
+
+  // ── Read OLD APPS folder contents before renaming ──────────────────
+  onProgress?.(35, "Reading APPS launcher folder contents…");
+  let oldElfFile: string | undefined;
+  let oldTitleCfgContent: string | undefined;
+  let readOk = false;
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const files = await fs.readdir(oldAppsFolder);
+      oldElfFile = files.find((f) => /\.ELF$/i.test(f));
+      try {
+        oldTitleCfgContent = await fs.readFile(path.join(oldAppsFolder, "title.cfg"), "utf-8");
+      } catch {
+        oldTitleCfgContent = "";
+      }
+      readOk = true;
+      break;
+    } catch {
+      if (attempt < 4) await new Promise((r) => setTimeout(r, 200));
+    }
+  }
+  if (!readOk) {
+    return { success: false, message: `Cannot read APPS folder "${oldAppsFolder}".` };
+  }
+
+  // ── Pre-compute new values ──────────────────────────────────────────
+  let newElfFile: string | undefined;
+  if (oldElfFile && /\.ELF$/i.test(oldElfFile)) {
+    const elfExt = path.extname(oldElfFile);
+    const elfStem = oldElfFile.slice(0, -elfExt.length);
+    const gIdx = elfStem.indexOf(gameId);
+    if (gIdx !== -1) {
+      newElfFile = `${elfStem.slice(0, gIdx)}${gameId}.${safeNewTitle}${elfExt}`;
+    } else {
+      // Fallback: try replacing oldTitle directly in the ELF stem
+      const tIdx = elfStem.lastIndexOf(oldTitle);
+      if (tIdx !== -1) {
+        newElfFile = `${elfStem.slice(0, tIdx)}${safeNewTitle}${elfExt}`;
+        log.verbose(`ELF name derived via oldTitle fallback: ${oldElfFile} → ${newElfFile}`);
+      } else {
+        log.warn(`ELF name lacks gameId "${gameId}" and oldTitle "${oldTitle}" — keeping existing`);
+        newElfFile = oldElfFile;
+      }
+    }
+  }
+
+  const bootVal = newElfFile ? `boot=${newElfFile}` : undefined;
+  const seenKeys = new Map<string, string>(); // lowercase key → original key text
+  const cfgLines = (oldTitleCfgContent ?? "").split("\n").map((line) => {
+    const t = line.trimEnd();
+    const eq = t.indexOf("=");
+    if (eq === -1) return line;
+    const k = t.slice(0, eq).trim();
+    const lower = k.toLowerCase();
+    if (!seenKeys.has(lower)) seenKeys.set(lower, k);
+    if (lower === "title") {
+      return k === "Title" ? `Title=${newTitle}` : `title=${newTitle}`;
+    }
+    if (lower === "boot" && bootVal) return bootVal;
+    return line;
+  });
+  const add: string[] = [];
+  if (!seenKeys.has("title")) { add.push(`title=${newTitle}`); add.push(`Title=${newTitle}`); }
+  if (!seenKeys.has("boot") && bootVal) add.push(bootVal);
+  const newCfgContent =
+    add.length > 0
+      ? cfgLines.join("\n") + (cfgLines.length && cfgLines[cfgLines.length - 1] !== "" ? "\n" : "") + add.join("\n") + "\n"
+      : cfgLines.join("\n");
+
+  // ── Rename the APPS launcher folder ─────────────────────────────────
+  onProgress?.(50, `Renaming APPS folder: POPS_${oldTitle}/ → POPS_${safeNewTitle}/`);
+  try {
+    await fs.rename(oldAppsFolder, newAppsFolder);
+    log.verbose(`APPS folder renamed: POPS_${oldTitle}/ → POPS_${safeNewTitle}/`);
+  } catch (err: any) {
+    log.error(`Failed to rename APPS launcher folder: ${err?.message || err}`);
+    return { success: false, message: `Failed to rename APPS launcher folder: ${err?.message || err}` };
+  }
+
+  log.info(`PS1 rename step 1 complete for "${oldTitle}" → "${safeNewTitle}"`);
+  return {
+    success: true,
+    newVcdPath,
+    oldElfFile,
+    newElfFile,
+    newCfgContent,
+    newAppsFolder,
+    safeNewTitle,
+  };
+}
+
+export async function renamePs1LauncherStep2(
+  params: {
+    newAppsFolder: string;
+    oldElfFile?: string;
+    newElfFile?: string;
+    newCfgContent?: string;
+    newTitle: string;
+  },
+  onProgress?: (percent: number, stage: string) => void
+): Promise<{
+  success: boolean;
+  message?: string;
+}> {
+  const { newAppsFolder, oldElfFile, newElfFile, newCfgContent, newTitle } = params;
+
+  log.info(`PS1 rename step 2: applying internal changes to ${newAppsFolder}`);
+
+  // ── Wait for the folder to be fully accessible ──────────────────────
+  onProgress?.(10, "Waiting for APPS folder to be ready…");
+  await new Promise((r) => setTimeout(r, 800));
+
+  let appsReady = false;
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      await fs.access(newAppsFolder, fs.constants.F_OK);
+      const files = await fs.readdir(newAppsFolder);
+      if (oldElfFile && !files.some((f) => /\.ELF$/i.test(f))) {
+        throw new Error("ELF not yet visible");
+      }
+      appsReady = true;
+      break;
+    } catch {
+      if (attempt < 9) await new Promise((r) => setTimeout(r, 500));
+    }
+  }
+  if (!appsReady) {
+    return { success: false, message: `APPS folder "${newAppsFolder}" is not ready.` };
+  }
+
+  // ── Rename the ELF file ────────────────────────────────────────────
+  if (oldElfFile && newElfFile && oldElfFile !== newElfFile) {
+    onProgress?.(40, `Renaming ELF: ${oldElfFile} → ${newElfFile}`);
+    const oldPath = path.join(newAppsFolder, oldElfFile);
+    const newPath = path.join(newAppsFolder, newElfFile);
+    let done = false;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      try {
+        await fs.rename(oldPath, newPath);
+        await fs.access(newPath, fs.constants.F_OK);
+        done = true;
+        break;
+      } catch {
+        if (attempt < 4) await new Promise((r) => setTimeout(r, 300));
+      }
+    }
+    if (!done) {
+      log.error(`ELF rename failed after retries: ${oldElfFile} → ${newElfFile}`);
+      return { success: false, message: `Failed to rename ELF after multiple attempts.` };
+    }
+    log.verbose(`ELF renamed: ${oldElfFile} → ${newElfFile}`);
+  }
+
+  // ── Write title.cfg ─────────────────────────────────────────────────
+  if (newCfgContent !== undefined) {
+    onProgress?.(70, "Updating title.cfg (title, Title, boot)");
+    const cfgPath = path.join(newAppsFolder, "title.cfg");
+    let done = false;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      try {
+        await fs.writeFile(cfgPath, newCfgContent, "utf-8");
+        const verify = await fs.readFile(cfgPath, "utf-8");
+        if (verify === newCfgContent) {
+          done = true;
+          break;
+        }
+      } catch {
+        if (attempt < 4) await new Promise((r) => setTimeout(r, 300));
+      }
+    }
+    if (!done) {
+      log.error(`title.cfg write failed after retries`);
+      return { success: false, message: `Failed to update title.cfg after multiple attempts.` };
+    }
+    log.verbose(`title.cfg updated`);
+  }
+
+  onProgress?.(100, "Rename complete");
+  log.info(`PS1 rename step 2 complete`);
+  return { success: true };
+}
+
 /**
  * Turns a low-level fs error into a message that explains the likely cause.
  * The common one on macOS: the user picks a .cue in the file dialog (granting

--- a/src/library.service.ts
+++ b/src/library.service.ts
@@ -545,6 +545,11 @@ export async function downloadArtByGameId(
 
   const saved = results.filter((r) => r.savedPath).length;
   log.info(`Artwork for ${gameId}: ${saved}/${types.length} file(s) downloaded`);
+  if (saved === 0) {
+    const msg = `No artwork found for ${gameId} in ${system} database.`;
+    log.warn(msg);
+    return { success: false, data: results, message: msg };
+  }
   return { success: true, data: results };
 }
 
@@ -880,6 +885,111 @@ export async function tryDetermineGameIdFromZso(filepath: string) {
   };
 }
 
+const VCD_HEADER_SIZE = 1048576; // 1 MB — VCD header before disc data
+
+/**
+ * Resolves a PS1 game ID from a VCD file by scanning the disc image data
+ * embedded after the 1 MB VCD header.
+ *
+ * VCD = POPStarter's container format: 1 MB TOC header followed by raw
+ * 2352-byte sectors from the original BIN. The PS1 game ID string lives in
+ * the ISO9660 volume descriptors / directory records of those sectors, so
+ * we scan from offset VCD_HEADER_SIZE using the same regex used for BIN files.
+ */
+export async function tryDeterminePs1GameIdFromVcd(
+  filepath: string
+): Promise<{
+  success: boolean;
+  gameId?: string;
+  formattedGameId?: string;
+  gameName?: string;
+  message?: string;
+}> {
+  let fileHandle: fs.FileHandle | undefined;
+
+  try {
+    fileHandle = await fs.open(filepath, "r");
+  } catch (err: any) {
+    log.error(`PS1 VCD scan: cannot open ${filepath}:`, err?.code || err?.message || err);
+    return {
+      success: false,
+      message: describeFileAccessError(err, filepath),
+    };
+  }
+
+  try {
+    log.verbose(`PS1 VCD scan: reading ${path.basename(filepath)} from offset 1 MB (VCD header skip)`);
+    const buffer = Buffer.alloc(FILE_SCAN_CHUNK_BYTES);
+    let position = VCD_HEADER_SIZE;
+    let carry = "";
+    const fileSize = (await fs.stat(filepath)).size;
+
+    while (position < fileSize) {
+      const { bytesRead } = await fileHandle.read(
+        buffer,
+        0,
+        FILE_SCAN_CHUNK_BYTES,
+        position
+      );
+
+      if (bytesRead === 0) {
+        break;
+      }
+
+      position += bytesRead;
+
+      const chunk = carry + buffer.subarray(0, bytesRead).toString("latin1");
+      PS1_GAME_ID_REGEX.lastIndex = 0;
+      const matches = chunk.match(PS1_GAME_ID_REGEX);
+
+      if (matches && matches.length > 0) {
+        const rawId = matches[0];
+        const gameId = rawId.replace("-", "_");
+        const lookupId = normaliseGameIdForLookup(gameId);
+        const gameName = await findPs1GameName(lookupId);
+
+        log.verbose(
+          `PS1 VCD scan: matched ${gameId} at offset ${position - bytesRead}` +
+            (gameName ? ` (${gameName})` : " (no title in games list)")
+        );
+        return {
+          success: true,
+          gameId,
+          formattedGameId: lookupId,
+          ...(gameName ? { gameName } : {}),
+        };
+      }
+
+      carry =
+        chunk.length > FILE_SCAN_OVERLAP_BYTES
+          ? chunk.slice(-FILE_SCAN_OVERLAP_BYTES)
+          : chunk;
+
+      // Safety bound — don't scan more than 64 MB of disc data for an ID
+      if (position - VCD_HEADER_SIZE > 64 * 1024 * 1024) {
+        log.verbose(`PS1 VCD scan: hit 64 MB safety bound for ${path.basename(filepath)}`);
+        break;
+      }
+    }
+
+    log.verbose(`PS1 VCD scan: no game ID found in ${path.basename(filepath)}`);
+    return {
+      success: false,
+      message: "Could not locate a PS1 game ID inside the VCD disc data.",
+    };
+  } catch (err: any) {
+    log.error(`PS1 VCD scan: read error on ${path.basename(filepath)}:`, err?.message || err);
+    return {
+      success: false,
+      message: err?.message || "Failed while reading VCD file contents.",
+    };
+  } finally {
+    if (fileHandle) {
+      await fileHandle.close();
+    }
+  }
+}
+
 export async function tryDeterminePs1GameIdFromHex(filepath: string) {
   let scanPath = filepath;
 
@@ -1017,7 +1127,8 @@ export async function openAskGameFiles(
 export async function deleteGameAndRelatedFiles(
   gamePath: string,
   artDir: string,
-  gameId: string
+  gameId: string,
+  launcherFolder?: string
 ) {
   log.info(`Deleting ${gameId} and related files: ${gamePath}`);
   try {
@@ -1043,25 +1154,23 @@ export async function deleteGameAndRelatedFiles(
       // ART directory may not exist — that's fine
     }
 
-    // PS1 VCDs are paired with an APPS/POPS_<sanitizedName>/ launcher created
-    // during import. Remove that folder too so PS1 deletes don't leave the
-    // launcher orphaned on disk.
-    if (path.extname(gamePath).toLowerCase() === ".vcd") {
-      const oplRoot = path.dirname(artDir); // artDir = <root>/ART
-      const base = path.basename(gamePath, path.extname(gamePath));
-      // Strip the "GAMEID." prefix if present; otherwise use the whole stem.
-      const prefix = `${gameId}.`;
-      const sanitizedName = base.startsWith(prefix)
-        ? base.slice(prefix.length)
-        : base;
-      if (sanitizedName) {
-        const appsLauncher = path.join(oplRoot, "APPS", `POPS_${sanitizedName}`);
+    // PS1 POPStarter VCDs (from POPS/ folder) are paired with an
+    // APPS/POPS_<name>/ launcher. The caller passes the exact folder name
+    // via launcherFolder — use it directly. VCD files from the VCD/ folder
+    // never have a paired launcher and pass undefined here.
+    if (launcherFolder) {
+      const oplRoot = path.dirname(artDir);
+      if (
+        !launcherFolder.includes("/") &&
+        !launcherFolder.includes("\\") &&
+        !launcherFolder.includes("..")
+      ) {
+        const appsLauncher = path.join(oplRoot, "APPS", launcherFolder);
         try {
           await fs.rm(appsLauncher, { recursive: true, force: true });
-          log.verbose(`Removed paired POPStarter launcher APPS/POPS_${sanitizedName}`);
+          log.verbose(`Removed paired POPStarter launcher APPS/${launcherFolder}`);
         } catch {
-          // Best-effort — the launcher may not exist (e.g. PS1 game imported
-          // outside this app), and that's fine.
+          // Best-effort — may not exist.
         }
       }
     }

--- a/src/library.service.ts
+++ b/src/library.service.ts
@@ -261,16 +261,16 @@ export async function getGamesFiles(dirPath: string) {
     // Only include files, skip directories
     const items = [
       ...items_cd.map((item) =>
-        Object.assign(item, { parentDir: dirPath + "/CD" })
+        Object.assign(item, { parentDir: path.join(dirPath, "CD") })
       ),
       ...items_dvd.map((item) =>
-        Object.assign(item, { parentDir: dirPath + "/DVD" })
+        Object.assign(item, { parentDir: path.join(dirPath, "DVD") })
       ),
       ...items_vcd.map((item) =>
-        Object.assign(item, { parentDir: dirPath + "/VCD" })
+        Object.assign(item, { parentDir: path.join(dirPath, "VCD") })
       ),
       ...items_pops.map((item) =>
-        Object.assign(item, { parentDir: dirPath + "/POPS" })
+        Object.assign(item, { parentDir: path.join(dirPath, "POPS") })
       ),
     ].filter((item) => {
       if (!item.isFile() || item.name.startsWith(".")) return false;
@@ -285,13 +285,14 @@ export async function getGamesFiles(dirPath: string) {
     const files = [];
 
     for (const item of items) {
-      const stats = await fs.stat(item.parentDir + "/" + item.name);
+      const fullPath = path.join(item.parentDir, item.name);
+      const stats = await fs.stat(fullPath);
 
       const itemInfo = {
         extension: path.extname(item.name),
         name: path.parse(item.name).name,
         parentPath: item.parentDir,
-        path: item.parentDir + "/" + item.name,
+        path: fullPath,
         stats,
       };
 
@@ -1440,19 +1441,19 @@ export async function deleteGameAndRelatedFiles(
 
   // 3. Delete POPStarter launcher folder (APPS/POPS_<name>/)
   if (launcherFolder) {
-    if (
-      !launcherFolder.includes("/") &&
-      !launcherFolder.includes("\\") &&
-      !launcherFolder.includes("..")
-    ) {
-      const appsLauncher = path.join(oplRoot, "APPS", launcherFolder);
+    const appsBase = path.join(oplRoot, "APPS");
+    const resolved = path.resolve(appsBase, launcherFolder);
+    if (!resolved.startsWith(appsBase + path.sep)) {
+      log.warn(`Path traversal attempt blocked: "${launcherFolder}" — refusing to delete`);
+      addEntry("Launcher folder", false, launcherFolder, "Path traversal blocked");
+    } else {
       try {
-        await fs.rm(appsLauncher, { recursive: true, force: true });
-        log.verbose(`Removed launcher folder ${rel(appsLauncher)}`);
-        addEntry("Launcher folder", true, rel(appsLauncher));
+        await fs.rm(resolved, { recursive: true, force: true });
+        log.verbose(`Removed launcher folder ${rel(resolved)}`);
+        addEntry("Launcher folder", true, rel(resolved));
       } catch (err: any) {
-        log.error(`Failed to remove launcher ${rel(appsLauncher)}:`, err?.message || err);
-        addEntry("Launcher folder", false, rel(appsLauncher), err?.message || String(err));
+        log.error(`Failed to remove launcher ${rel(resolved)}:`, err?.message || err);
+        addEntry("Launcher folder", false, rel(resolved), err?.message || String(err));
       }
     }
   }

--- a/src/library.service.ts
+++ b/src/library.service.ts
@@ -1372,25 +1372,59 @@ export async function openAskGameFiles(
   return result;
 }
 
+export interface DeleteEntry {
+  label: string;
+  path?: string;
+  success: boolean;
+  error?: string;
+}
+
+export interface DeleteGameResult {
+  success: boolean;
+  message?: string;
+  entries: DeleteEntry[];
+}
+
 export async function deleteGameAndRelatedFiles(
   gamePath: string,
   artDir: string,
   gameId: string,
   launcherFolder?: string
-) {
+): Promise<DeleteGameResult> {
   log.info(`Deleting ${gameId} and related files: ${gamePath}`);
-  try {
-    // Delete the game file
-    await fs.unlink(gamePath);
-    log.verbose(`Removed disc image ${path.basename(gamePath)}`);
+  const entries: DeleteEntry[] = [];
 
-    // Delete related artwork files (e.g., SLUS_123.45_COV.png)
+  const addEntry = (label: string, success: boolean, path?: string, error?: string) => {
+    entries.push({ label, path, success, error });
+  };
+
+  const oplRoot = path.dirname(artDir);
+
+  // Helper: show path relative to OPL root
+  const rel = (p: string) => path.relative(oplRoot, p);
+
+  // 1. Delete the game file (VCD in POPS/)
+  let hasCriticalError = false;
+  try {
+    await fs.unlink(gamePath);
+    log.verbose(`Removed game file ${path.basename(gamePath)}`);
+    addEntry("VCD", true, rel(gamePath));
+  } catch (err: any) {
+    hasCriticalError = true;
+    log.error(`Failed to remove game file ${path.basename(gamePath)}:`, err?.message || err);
+    addEntry("VCD", false, rel(gamePath), err?.message || String(err));
+  }
+
+  // 2. For non-PS1 games only, delete related artwork files
+  if (!launcherFolder) {
     try {
       const artFiles = await fs.readdir(artDir);
       const relatedArt = artFiles.filter((f) => f.startsWith(gameId + "_"));
+      let deleted = 0;
       for (const artFile of relatedArt) {
         try {
           await fs.unlink(path.join(artDir, artFile));
+          deleted++;
         } catch {
           // Ignore individual art file deletion failures
         }
@@ -1398,37 +1432,79 @@ export async function deleteGameAndRelatedFiles(
       if (relatedArt.length > 0) {
         log.verbose(`Removed ${relatedArt.length} artwork file(s) for ${gameId}`);
       }
+      addEntry("Artwork", true, deleted > 0 ? `${deleted} file(s)` : "None found");
     } catch {
-      // ART directory may not exist — that's fine
+      addEntry("Artwork", true, "No artwork directory");
     }
+  }
 
-    // PS1 POPStarter VCDs (from POPS/ folder) are paired with an
-    // APPS/POPS_<name>/ launcher. The caller passes the exact folder name
-    // via launcherFolder — use it directly. VCD files from the VCD/ folder
-    // never have a paired launcher and pass undefined here.
-    if (launcherFolder) {
-      const oplRoot = path.dirname(artDir);
-      if (
-        !launcherFolder.includes("/") &&
-        !launcherFolder.includes("\\") &&
-        !launcherFolder.includes("..")
-      ) {
-        const appsLauncher = path.join(oplRoot, "APPS", launcherFolder);
-        try {
-          await fs.rm(appsLauncher, { recursive: true, force: true });
-          log.verbose(`Removed paired POPStarter launcher APPS/${launcherFolder}`);
-        } catch {
-          // Best-effort — may not exist.
-        }
+  // 3. Delete POPStarter launcher folder (APPS/POPS_<name>/)
+  if (launcherFolder) {
+    if (
+      !launcherFolder.includes("/") &&
+      !launcherFolder.includes("\\") &&
+      !launcherFolder.includes("..")
+    ) {
+      const appsLauncher = path.join(oplRoot, "APPS", launcherFolder);
+      try {
+        await fs.rm(appsLauncher, { recursive: true, force: true });
+        log.verbose(`Removed launcher folder ${rel(appsLauncher)}`);
+        addEntry("Launcher folder", true, rel(appsLauncher));
+      } catch (err: any) {
+        log.error(`Failed to remove launcher ${rel(appsLauncher)}:`, err?.message || err);
+        addEntry("Launcher folder", false, rel(appsLauncher), err?.message || String(err));
       }
     }
-
-    log.info(`Deleted ${gameId}`);
-    return { success: true };
-  } catch (err: any) {
-    log.error(`Failed to delete ${gameId} (${gamePath}):`, err?.message || err);
-    return { success: false, message: err?.message || String(err) };
   }
+
+  // 4. Delete per-game POPS subfolder (POPS/<title>/) containing VMC files etc.
+  if (launcherFolder) {
+    const vcdName = path.basename(gamePath);
+    const ext = path.extname(vcdName);
+    const gameTitle = vcdName.slice(0, -ext.length);
+    const popsDir = path.dirname(gamePath);
+    const popsSubdir = path.join(popsDir, gameTitle);
+
+    try {
+      await fs.access(popsSubdir);
+      // Folder exists — enumerate and delete each file inside
+      const files = await fs.readdir(popsSubdir);
+      for (const f of files) {
+        const filePath = path.join(popsSubdir, f);
+        try {
+          await fs.unlink(filePath);
+          log.verbose(`Removed file ${rel(filePath)}`);
+          addEntry("POPS subfolder file", true, rel(filePath));
+        } catch (err: any) {
+          addEntry("POPS subfolder file", false, rel(filePath), err?.message || String(err));
+        }
+      }
+      // Remove the now-empty folder
+      try {
+        await fs.rmdir(popsSubdir);
+        log.verbose(`Removed POPS subfolder ${rel(popsSubdir)}`);
+        addEntry("POPS subfolder", true, rel(popsSubdir));
+      } catch (err: any) {
+        addEntry("POPS subfolder", false, rel(popsSubdir), err?.message || String(err));
+      }
+    } catch {
+      // Folder doesn't exist — not an error
+      addEntry("POPS subfolder", true, "Not present");
+    }
+  }
+
+  if (hasCriticalError) {
+    log.error(`Failed to delete game file for ${gameId}`);
+    return { success: false, message: entries.find((e) => e.label === "Game file")?.error, entries };
+  }
+
+  const allSuccess = entries.every((e) => e.success);
+  if (!allSuccess) {
+    log.info(`Deleted ${gameId} with some non-critical errors`);
+  } else {
+    log.info(`Deleted ${gameId} successfully`);
+  }
+  return { success: true, entries };
 }
 
 export async function moveFile(

--- a/src/library.service.ts
+++ b/src/library.service.ts
@@ -1481,13 +1481,16 @@ export async function deleteGameAndRelatedFiles(
   gamePath: string,
   artDir: string,
   gameId: string,
-  launcherFolder?: string
+  launcherFolder?: string,
+  onProgress?: (entry: DeleteEntry) => void
 ): Promise<DeleteGameResult> {
   log.info(`Deleting ${gameId} and related files: ${gamePath}`);
   const entries: DeleteEntry[] = [];
 
   const addEntry = (label: string, success: boolean, path?: string, error?: string) => {
-    entries.push({ label, path, success, error });
+    const entry: DeleteEntry = { label, path, success, error };
+    entries.push(entry);
+    if (onProgress) onProgress(entry);
   };
 
   const oplRoot = path.dirname(artDir);

--- a/src/library.service.ts
+++ b/src/library.service.ts
@@ -1576,10 +1576,9 @@ export async function deleteGameAndRelatedFiles(
     const artPrefix = bootName || gameId;
     try {
       const artFiles = await fs.readdir(artDir);
-      const relatedArt = artFiles.filter((f) => {
-        const base = path.parse(f).name;
-        return f.startsWith(artPrefix + "_") && !f.startsWith(".");
-      });
+    const relatedArt = artFiles.filter((f) =>
+      f.startsWith(artPrefix + "_") && !f.startsWith(".")
+    );
       if (relatedArt.length > 0) {
         log.verbose(`Removing ${relatedArt.length} artwork file(s) for ${artPrefix}`);
         for (const artFile of relatedArt) {

--- a/src/library.service.ts
+++ b/src/library.service.ts
@@ -664,9 +664,10 @@ export async function renamePs1LauncherStep1(
 
   // ── Rename the VCD file ─────────────────────────────────────────────
   onProgress?.(15, `Renaming VCD: ${vcdBasename} → ${newVcdBasename}`);
+  log.info(`Renaming VCD: ${vcdBasename} → ${newVcdBasename}`);
   try {
     await fs.rename(vcdPath, newVcdPath);
-    log.verbose(`VCD renamed: ${vcdBasename} → ${newVcdBasename}`);
+    log.info(`VCD renamed: ${vcdBasename} → ${newVcdBasename}`);
   } catch (err: any) {
     log.error(`Failed to rename VCD: ${err?.message || err}`);
     return { success: false, message: `Failed to rename VCD: ${err?.message || err}` };
@@ -674,6 +675,7 @@ export async function renamePs1LauncherStep1(
 
   // ── Rename POPS VMC subfolder (if exists) ───────────────────────────
   onProgress?.(25, `Renaming VMC folder: ${oldTitle}/ → ${safeNewTitle}/`);
+  log.info(`Renaming VMC folder: ${oldTitle}/ → ${safeNewTitle}/`);
   try {
     await fs.access(path.join(popsDir, oldTitle));
     await fs.rename(path.join(popsDir, oldTitle), path.join(popsDir, safeNewTitle));
@@ -743,6 +745,7 @@ export async function renamePs1LauncherStep1(
   const add: string[] = [];
   if (!seenKeys.has("title")) { add.push(`title=${newTitle}`); add.push(`Title=${newTitle}`); }
   if (!seenKeys.has("boot") && bootVal) add.push(bootVal);
+  if (!seenKeys.has("gameid")) add.push(`GameID=${gameId}`);
   const newCfgContent =
     add.length > 0
       ? cfgLines.join("\n") + (cfgLines.length && cfgLines[cfgLines.length - 1] !== "" ? "\n" : "") + add.join("\n") + "\n"
@@ -750,9 +753,10 @@ export async function renamePs1LauncherStep1(
 
   // ── Rename the APPS launcher folder ─────────────────────────────────
   onProgress?.(50, `Renaming APPS folder: POPS_${oldTitle}/ → POPS_${safeNewTitle}/`);
+  log.info(`Renaming APPS folder: POPS_${oldTitle}/ → POPS_${safeNewTitle}/`);
   try {
     await fs.rename(oldAppsFolder, newAppsFolder);
-    log.verbose(`APPS folder renamed: POPS_${oldTitle}/ → POPS_${safeNewTitle}/`);
+    log.info(`APPS folder renamed: POPS_${oldTitle}/ → POPS_${safeNewTitle}/`);
   } catch (err: any) {
     log.error(`Failed to rename APPS launcher folder: ${err?.message || err}`);
     return { success: false, message: `Failed to rename APPS launcher folder: ${err?.message || err}` };
@@ -812,6 +816,7 @@ export async function renamePs1LauncherStep2(
   // ── Rename the ELF file ────────────────────────────────────────────
   if (oldElfFile && newElfFile && oldElfFile !== newElfFile) {
     onProgress?.(40, `Renaming ELF: ${oldElfFile} → ${newElfFile}`);
+    log.info(`Renaming ELF: ${oldElfFile} → ${newElfFile}`);
     const oldPath = path.join(newAppsFolder, oldElfFile);
     const newPath = path.join(newAppsFolder, newElfFile);
     let done = false;
@@ -829,12 +834,13 @@ export async function renamePs1LauncherStep2(
       log.error(`ELF rename failed after retries: ${oldElfFile} → ${newElfFile}`);
       return { success: false, message: `Failed to rename ELF after multiple attempts.` };
     }
-    log.verbose(`ELF renamed: ${oldElfFile} → ${newElfFile}`);
+    log.info(`ELF renamed: ${oldElfFile} → ${newElfFile}`);
   }
 
   // ── Write title.cfg ─────────────────────────────────────────────────
   if (newCfgContent !== undefined) {
     onProgress?.(70, "Updating title.cfg (title, Title, boot)");
+    log.info("Updating title.cfg (title, Title, boot)");
     const cfgPath = path.join(newAppsFolder, "title.cfg");
     let done = false;
     for (let attempt = 0; attempt < 5; attempt++) {
@@ -853,7 +859,7 @@ export async function renamePs1LauncherStep2(
       log.error(`title.cfg write failed after retries`);
       return { success: false, message: `Failed to update title.cfg after multiple attempts.` };
     }
-    log.verbose(`title.cfg updated`);
+    log.info(`title.cfg updated`);
   }
 
   onProgress?.(100, "Rename complete");

--- a/src/library.service.ts
+++ b/src/library.service.ts
@@ -1482,7 +1482,8 @@ export async function deleteGameAndRelatedFiles(
   artDir: string,
   gameId: string,
   launcherFolder?: string,
-  onProgress?: (entry: DeleteEntry) => void
+  onProgress?: (entry: DeleteEntry) => void,
+  bootName?: string,
 ): Promise<DeleteGameResult> {
   log.info(`Deleting ${gameId} and related files: ${gamePath}`);
   const entries: DeleteEntry[] = [];
@@ -1510,30 +1511,7 @@ export async function deleteGameAndRelatedFiles(
     addEntry("VCD", false, rel(gamePath), err?.message || String(err));
   }
 
-  // 2. For non-PS1 games only, delete related artwork files
-  if (!launcherFolder) {
-    try {
-      const artFiles = await fs.readdir(artDir);
-      const relatedArt = artFiles.filter((f) => f.startsWith(gameId + "_"));
-      let deleted = 0;
-      for (const artFile of relatedArt) {
-        try {
-          await fs.unlink(path.join(artDir, artFile));
-          deleted++;
-        } catch {
-          // Ignore individual art file deletion failures
-        }
-      }
-      if (relatedArt.length > 0) {
-        log.verbose(`Removed ${relatedArt.length} artwork file(s) for ${gameId}`);
-      }
-      addEntry("Artwork", true, deleted > 0 ? `${deleted} file(s)` : "None found");
-    } catch {
-      addEntry("Artwork", true, "No artwork directory");
-    }
-  }
-
-  // 3. Delete POPStarter launcher folder (APPS/POPS_<name>/)
+  // 2. Delete POPStarter launcher folder (APPS/POPS_<name>/)
   if (launcherFolder) {
     const appsBase = path.join(oplRoot, "APPS");
     const resolved = path.resolve(appsBase, launcherFolder);
@@ -1585,6 +1563,39 @@ export async function deleteGameAndRelatedFiles(
     } catch {
       // Folder doesn't exist — not an error
       addEntry("POPS subfolder", true, "Not present");
+    }
+  }
+
+  // 4. Delete related artwork files
+  //    Disc games match by gameId prefix (XXXX_###.##_TYPE.png),
+  //    PS1 launcher apps match by bootName prefix (boot.ELF_TYPE.png).
+  //    For PS1 launchers, skip artwork unless bootName is explicitly provided.
+  if (launcherFolder && !bootName) {
+    // Artwork intentionally omitted — user unchecked the option.
+  } else {
+    const artPrefix = bootName || gameId;
+    try {
+      const artFiles = await fs.readdir(artDir);
+      const relatedArt = artFiles.filter((f) => {
+        const base = path.parse(f).name;
+        return f.startsWith(artPrefix + "_") && !f.startsWith(".");
+      });
+      if (relatedArt.length > 0) {
+        log.verbose(`Removing ${relatedArt.length} artwork file(s) for ${artPrefix}`);
+        for (const artFile of relatedArt) {
+          const artPath = path.join(artDir, artFile);
+          try {
+            await fs.unlink(artPath);
+            addEntry("Artwork", true, rel(artPath));
+          } catch (err: any) {
+            addEntry("Artwork", false, rel(artPath), err?.message || String(err));
+          }
+        }
+      } else {
+        addEntry("Artwork", true, "None found");
+      }
+    } catch {
+      addEntry("Artwork", true, "No artwork directory");
     }
   }
 

--- a/src/library.service.ts
+++ b/src/library.service.ts
@@ -620,6 +620,163 @@ export async function renameGamefile(
   }
 }
 
+// ── PS1 rename progress percentages ──────────────────────────────
+const PROGRESS_APPS_WAIT = 10;
+const PROGRESS_VCD_RENAME = 15;
+const PROGRESS_POPS_SUBFOLDER = 25;
+const PROGRESS_READ_APPS = 35;
+const PROGRESS_ELF_RENAME = 40;
+const PROGRESS_APPS_RENAME = 50;
+const PROGRESS_CFG_WRITE = 70;
+const PROGRESS_DONE = 100;
+
+// ── PS1 rename retry timing (ms) ─────────────────────────────────
+const RENAME_STEP2_RETRY_MAX = 10;
+const RENAME_STEP2_RETRY_DELAY_MS = 500;
+const RENAME_ELF_RETRY_MAX = 5;
+const RENAME_ELF_RETRY_DELAY_MS = 300;
+const TITLE_CFG_POST_WRITE_DELAY_MS = 800;
+
+function deriveOldTitle(vcdPath: string, gameId: string): string | null {
+  const vcdBasename = path.basename(vcdPath);
+  const vcdExt = path.extname(vcdBasename);
+  const vcdStem = vcdBasename.slice(0, -vcdExt.length);
+  const prefix = `${gameId}.`;
+  const oldTitle = vcdStem.startsWith(prefix) ? vcdStem.slice(prefix.length) : vcdStem;
+  return oldTitle || null;
+}
+
+async function renameVcdFile(
+  vcdPath: string,
+  newVcdPath: string,
+  vcdBasename: string,
+  newVcdBasename: string,
+  onProgress?: (percent: number, stage: string) => void,
+): Promise<string | null> {
+  onProgress?.(PROGRESS_VCD_RENAME, `Renaming VCD: ${vcdBasename} → ${newVcdBasename}`);
+  log.info(`Renaming VCD: ${vcdBasename} → ${newVcdBasename}`);
+  try {
+    await fs.rename(vcdPath, newVcdPath);
+    log.info(`VCD renamed: ${vcdBasename} → ${newVcdBasename}`);
+    return null;
+  } catch (err: unknown) {
+    const msg = `Failed to rename VCD: ${err instanceof Error ? err.message : String(err)}`;
+    log.error(msg);
+    return msg;
+  }
+}
+
+async function renamePopsSubfolder(
+  popsDir: string,
+  oldTitle: string,
+  safeNewTitle: string,
+  onProgress?: (percent: number, stage: string) => void,
+): Promise<void> {
+  onProgress?.(PROGRESS_POPS_SUBFOLDER, `Renaming VMC folder: ${oldTitle}/ → ${safeNewTitle}/`);
+  log.info(`Renaming VMC folder: ${oldTitle}/ → ${safeNewTitle}/`);
+  try {
+    await fs.access(path.join(popsDir, oldTitle));
+    await fs.rename(path.join(popsDir, oldTitle), path.join(popsDir, safeNewTitle));
+    log.verbose(`POPS VMC subfolder renamed`);
+  } catch (err: unknown) {
+    if (err instanceof Error && 'code' in err && (err as NodeJS.ErrnoException).code === 'ENOENT') {
+      log.verbose(`POPS VMC subfolder does not exist — skipping`);
+    } else {
+      log.warn(`Failed to rename POPS VMC subfolder: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+}
+
+interface AppsFolderContents {
+  oldElfFile?: string;
+  oldTitleCfgContent: string;
+}
+
+async function readAppsFolderContents(oldAppsFolder: string): Promise<AppsFolderContents | null> {
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      const files = await fs.readdir(oldAppsFolder);
+      const oldElfFile = files.find((f) => /\.ELF$/i.test(f));
+      let oldTitleCfgContent = "";
+      try {
+        oldTitleCfgContent = await fs.readFile(path.join(oldAppsFolder, "title.cfg"), "utf-8");
+      } catch { /* no title.cfg — fine */ }
+      return { oldElfFile, oldTitleCfgContent };
+    } catch {
+      if (attempt < 4) await new Promise((r) => setTimeout(r, 200));
+    }
+  }
+  return null;
+}
+
+function computeNewElfName(
+  oldElfFile: string | undefined,
+  gameId: string,
+  oldTitle: string,
+  safeNewTitle: string,
+): string | undefined {
+  if (!oldElfFile || !/\.ELF$/i.test(oldElfFile)) return undefined;
+
+  const elfExt = path.extname(oldElfFile);
+  const elfStem = oldElfFile.slice(0, -elfExt.length);
+  const gIdx = elfStem.indexOf(gameId);
+  if (gIdx !== -1) {
+    return `${elfStem.slice(0, gIdx)}${gameId}.${safeNewTitle}${elfExt}`;
+  }
+
+  const tIdx = elfStem.lastIndexOf(oldTitle);
+  if (tIdx !== -1) {
+    const newName = `${elfStem.slice(0, tIdx)}${safeNewTitle}${elfExt}`;
+    log.verbose(`ELF name derived via oldTitle fallback: ${oldElfFile} → ${newName}`);
+    return newName;
+  }
+
+  log.warn(`ELF name lacks gameId "${gameId}" and oldTitle "${oldTitle}" — keeping existing`);
+  return oldElfFile;
+}
+
+interface CfgBuildResult {
+  content: string;
+  bootVal?: string;
+}
+
+function buildNewCfgContent(
+  oldTitleCfgContent: string,
+  newTitle: string,
+  newElfFile: string | undefined,
+  gameId: string,
+): CfgBuildResult {
+  const bootVal = newElfFile ? `boot=${newElfFile}` : undefined;
+  const seenKeys = new Map<string, string>();
+
+  const cfgLines = oldTitleCfgContent.split("\n").map((line) => {
+    const t = line.trimEnd();
+    const eq = t.indexOf("=");
+    if (eq === -1) return line;
+    const k = t.slice(0, eq).trim();
+    const lower = k.toLowerCase();
+    if (!seenKeys.has(lower)) seenKeys.set(lower, k);
+    if (lower === "title") {
+      return k === "Title" ? `Title=${newTitle}` : `title=${newTitle}`;
+    }
+    if (lower === "boot" && bootVal) return bootVal;
+    return line;
+  });
+
+  const add: string[] = [];
+  // OPL's title.cfg parser may look for either casing — add both for compatibility
+  if (!seenKeys.has("title")) { add.push(`title=${newTitle}`); add.push(`Title=${newTitle}`); }
+  if (!seenKeys.has("boot") && bootVal) add.push(bootVal);
+  if (!seenKeys.has("gameid")) add.push(`GameID=${gameId}`);
+
+  const content =
+    add.length > 0
+      ? cfgLines.join("\n") + (cfgLines.length && cfgLines[cfgLines.length - 1] !== "" ? "\n" : "") + add.join("\n") + "\n"
+      : cfgLines.join("\n");
+
+  return { content, bootVal };
+}
+
 export async function renamePs1LauncherStep1(
   vcdPath: string,
   gameId: string,
@@ -642,12 +799,8 @@ export async function renamePs1LauncherStep1(
 
   const popsDir = path.dirname(vcdPath);
   const oplRoot = path.resolve(popsDir, "..");
-  const vcdBasename = path.basename(vcdPath);
-  const vcdExt = path.extname(vcdBasename);
-  const vcdStem = vcdBasename.slice(0, -vcdExt.length);
-  const prefix = `${gameId}.`;
-  const oldTitle = vcdStem.startsWith(prefix) ? vcdStem.slice(prefix.length) : vcdStem;
 
+  const oldTitle = deriveOldTitle(vcdPath, gameId);
   if (!oldTitle) {
     return { success: false, message: "Could not derive the current game title from the VCD filename." };
   }
@@ -657,6 +810,8 @@ export async function renamePs1LauncherStep1(
 
   log.info(`PS1 rename step 1: "${oldTitle}" → "${safeNewTitle}" (gameId=${gameId})`);
 
+  const vcdBasename = path.basename(vcdPath);
+  const vcdExt = path.extname(vcdBasename);
   const newVcdBasename = `${safeNewTitle}${vcdExt}`;
   const newVcdPath = path.join(popsDir, newVcdBasename);
   const appsDir = path.join(oplRoot, "APPS");
@@ -664,110 +819,46 @@ export async function renamePs1LauncherStep1(
   const newAppsFolder = path.join(appsDir, `POPS_${safeNewTitle}`);
 
   // ── Rename the VCD file ─────────────────────────────────────────────
-  onProgress?.(15, `Renaming VCD: ${vcdBasename} → ${newVcdBasename}`);
-  log.info(`Renaming VCD: ${vcdBasename} → ${newVcdBasename}`);
-  try {
-    await fs.rename(vcdPath, newVcdPath);
-    log.info(`VCD renamed: ${vcdBasename} → ${newVcdBasename}`);
-  } catch (err: any) {
-    log.error(`Failed to rename VCD: ${err?.message || err}`);
-    return { success: false, message: `Failed to rename VCD: ${err?.message || err}` };
-  }
+  const vcdError = await renameVcdFile(vcdPath, newVcdPath, vcdBasename, newVcdBasename, onProgress);
+  if (vcdError) return { success: false, message: vcdError };
 
   // ── Rename POPS VMC subfolder (if exists) ───────────────────────────
-  onProgress?.(25, `Renaming VMC folder: ${oldTitle}/ → ${safeNewTitle}/`);
-  log.info(`Renaming VMC folder: ${oldTitle}/ → ${safeNewTitle}/`);
-  try {
-    await fs.access(path.join(popsDir, oldTitle));
-    await fs.rename(path.join(popsDir, oldTitle), path.join(popsDir, safeNewTitle));
-    log.verbose(`POPS VMC subfolder renamed`);
-  } catch { /* doesn't exist — fine */ }
+  await renamePopsSubfolder(popsDir, oldTitle, safeNewTitle, onProgress);
 
   // ── Read OLD APPS folder contents before renaming ──────────────────
-  onProgress?.(35, "Reading APPS launcher folder contents…");
-  let oldElfFile: string | undefined;
-  let oldTitleCfgContent: string | undefined;
-  let readOk = false;
-  for (let attempt = 0; attempt < 5; attempt++) {
-    try {
-      const files = await fs.readdir(oldAppsFolder);
-      oldElfFile = files.find((f) => /\.ELF$/i.test(f));
-      try {
-        oldTitleCfgContent = await fs.readFile(path.join(oldAppsFolder, "title.cfg"), "utf-8");
-      } catch {
-        oldTitleCfgContent = "";
-      }
-      readOk = true;
-      break;
-    } catch {
-      if (attempt < 4) await new Promise((r) => setTimeout(r, 200));
-    }
-  }
-  if (!readOk) {
+  onProgress?.(PROGRESS_READ_APPS, "Reading APPS launcher folder contents…");
+  const appsContents = await readAppsFolderContents(oldAppsFolder);
+  if (!appsContents) {
     return { success: false, message: `Cannot read APPS folder "${oldAppsFolder}".` };
   }
 
   // ── Pre-compute new values ──────────────────────────────────────────
-  let newElfFile: string | undefined;
-  if (oldElfFile && /\.ELF$/i.test(oldElfFile)) {
-    const elfExt = path.extname(oldElfFile);
-    const elfStem = oldElfFile.slice(0, -elfExt.length);
-    const gIdx = elfStem.indexOf(gameId);
-    if (gIdx !== -1) {
-      newElfFile = `${elfStem.slice(0, gIdx)}${gameId}.${safeNewTitle}${elfExt}`;
-    } else {
-      // Fallback: try replacing oldTitle directly in the ELF stem
-      const tIdx = elfStem.lastIndexOf(oldTitle);
-      if (tIdx !== -1) {
-        newElfFile = `${elfStem.slice(0, tIdx)}${safeNewTitle}${elfExt}`;
-        log.verbose(`ELF name derived via oldTitle fallback: ${oldElfFile} → ${newElfFile}`);
-      } else {
-        log.warn(`ELF name lacks gameId "${gameId}" and oldTitle "${oldTitle}" — keeping existing`);
-        newElfFile = oldElfFile;
-      }
-    }
-  }
+  const newElfFile = computeNewElfName(appsContents.oldElfFile, gameId, oldTitle, safeNewTitle);
 
-  const bootVal = newElfFile ? `boot=${newElfFile}` : undefined;
-  const seenKeys = new Map<string, string>(); // lowercase key → original key text
-  const cfgLines = (oldTitleCfgContent ?? "").split("\n").map((line) => {
-    const t = line.trimEnd();
-    const eq = t.indexOf("=");
-    if (eq === -1) return line;
-    const k = t.slice(0, eq).trim();
-    const lower = k.toLowerCase();
-    if (!seenKeys.has(lower)) seenKeys.set(lower, k);
-    if (lower === "title") {
-      return k === "Title" ? `Title=${newTitle}` : `title=${newTitle}`;
-    }
-    if (lower === "boot" && bootVal) return bootVal;
-    return line;
-  });
-  const add: string[] = [];
-  if (!seenKeys.has("title")) { add.push(`title=${newTitle}`); add.push(`Title=${newTitle}`); }
-  if (!seenKeys.has("boot") && bootVal) add.push(bootVal);
-  if (!seenKeys.has("gameid")) add.push(`GameID=${gameId}`);
-  const newCfgContent =
-    add.length > 0
-      ? cfgLines.join("\n") + (cfgLines.length && cfgLines[cfgLines.length - 1] !== "" ? "\n" : "") + add.join("\n") + "\n"
-      : cfgLines.join("\n");
+  const { content: newCfgContent } = buildNewCfgContent(
+    appsContents.oldTitleCfgContent,
+    newTitle,
+    newElfFile,
+    gameId,
+  );
 
   // ── Rename the APPS launcher folder ─────────────────────────────────
-  onProgress?.(50, `Renaming APPS folder: POPS_${oldTitle}/ → POPS_${safeNewTitle}/`);
+  onProgress?.(PROGRESS_APPS_RENAME, `Renaming APPS folder: POPS_${oldTitle}/ → POPS_${safeNewTitle}/`);
   log.info(`Renaming APPS folder: POPS_${oldTitle}/ → POPS_${safeNewTitle}/`);
   try {
     await fs.rename(oldAppsFolder, newAppsFolder);
     log.info(`APPS folder renamed: POPS_${oldTitle}/ → POPS_${safeNewTitle}/`);
-  } catch (err: any) {
-    log.error(`Failed to rename APPS launcher folder: ${err?.message || err}`);
-    return { success: false, message: `Failed to rename APPS launcher folder: ${err?.message || err}` };
+  } catch (err: unknown) {
+    const msg = `Failed to rename APPS launcher folder: ${err instanceof Error ? err.message : String(err)}`;
+    log.error(msg);
+    return { success: false, message: msg };
   }
 
   log.info(`PS1 rename step 1 complete for "${oldTitle}" → "${safeNewTitle}"`);
   return {
     success: true,
     newVcdPath,
-    oldElfFile,
+    oldElfFile: appsContents.oldElfFile,
     newElfFile,
     newCfgContent,
     newAppsFolder,
@@ -793,11 +884,11 @@ export async function renamePs1LauncherStep2(
   log.info(`PS1 rename step 2: applying internal changes to ${newAppsFolder}`);
 
   // ── Wait for the folder to be fully accessible ──────────────────────
-  onProgress?.(10, "Waiting for APPS folder to be ready…");
-  await new Promise((r) => setTimeout(r, 800));
+  onProgress?.(PROGRESS_APPS_WAIT, "Waiting for APPS folder to be ready…");
+  await new Promise((r) => setTimeout(r, TITLE_CFG_POST_WRITE_DELAY_MS));
 
   let appsReady = false;
-  for (let attempt = 0; attempt < 10; attempt++) {
+  for (let attempt = 0; attempt < RENAME_STEP2_RETRY_MAX; attempt++) {
     try {
       await fs.access(newAppsFolder, fs.constants.F_OK);
       const files = await fs.readdir(newAppsFolder);
@@ -807,7 +898,7 @@ export async function renamePs1LauncherStep2(
       appsReady = true;
       break;
     } catch {
-      if (attempt < 9) await new Promise((r) => setTimeout(r, 500));
+      if (attempt < RENAME_STEP2_RETRY_MAX - 1) await new Promise((r) => setTimeout(r, RENAME_STEP2_RETRY_DELAY_MS));
     }
   }
   if (!appsReady) {
@@ -816,19 +907,19 @@ export async function renamePs1LauncherStep2(
 
   // ── Rename the ELF file ────────────────────────────────────────────
   if (oldElfFile && newElfFile && oldElfFile !== newElfFile) {
-    onProgress?.(40, `Renaming ELF: ${oldElfFile} → ${newElfFile}`);
+    onProgress?.(PROGRESS_ELF_RENAME, `Renaming ELF: ${oldElfFile} → ${newElfFile}`);
     log.info(`Renaming ELF: ${oldElfFile} → ${newElfFile}`);
     const oldPath = path.join(newAppsFolder, oldElfFile);
     const newPath = path.join(newAppsFolder, newElfFile);
     let done = false;
-    for (let attempt = 0; attempt < 5; attempt++) {
+    for (let attempt = 0; attempt < RENAME_ELF_RETRY_MAX; attempt++) {
       try {
         await fs.rename(oldPath, newPath);
         await fs.access(newPath, fs.constants.F_OK);
         done = true;
         break;
       } catch {
-        if (attempt < 4) await new Promise((r) => setTimeout(r, 300));
+        if (attempt < RENAME_ELF_RETRY_MAX - 1) await new Promise((r) => setTimeout(r, RENAME_ELF_RETRY_DELAY_MS));
       }
     }
     if (!done) {
@@ -840,11 +931,11 @@ export async function renamePs1LauncherStep2(
 
   // ── Write title.cfg ─────────────────────────────────────────────────
   if (newCfgContent !== undefined) {
-    onProgress?.(70, "Updating title.cfg (title, Title, boot)");
+    onProgress?.(PROGRESS_CFG_WRITE, "Updating title.cfg (title, Title, boot)");
     log.info("Updating title.cfg (title, Title, boot)");
     const cfgPath = path.join(newAppsFolder, "title.cfg");
     let done = false;
-    for (let attempt = 0; attempt < 5; attempt++) {
+    for (let attempt = 0; attempt < RENAME_ELF_RETRY_MAX; attempt++) {
       try {
         await fs.writeFile(cfgPath, newCfgContent, "utf-8");
         const verify = await fs.readFile(cfgPath, "utf-8");
@@ -853,7 +944,7 @@ export async function renamePs1LauncherStep2(
           break;
         }
       } catch {
-        if (attempt < 4) await new Promise((r) => setTimeout(r, 300));
+        if (attempt < RENAME_ELF_RETRY_MAX - 1) await new Promise((r) => setTimeout(r, RENAME_ELF_RETRY_DELAY_MS));
       }
     }
     if (!done) {
@@ -863,7 +954,7 @@ export async function renamePs1LauncherStep2(
     log.info(`title.cfg updated`);
   }
 
-  onProgress?.(100, "Rename complete");
+  onProgress?.(PROGRESS_DONE, "Rename complete");
   log.info(`PS1 rename step 2 complete`);
   return { success: true };
 }
@@ -1496,7 +1587,7 @@ export async function deleteGameAndRelatedFiles(
 
   if (hasCriticalError) {
     log.error(`Failed to delete game file for ${gameId}`);
-    return { success: false, message: entries.find((e) => e.label === "Game file")?.error, entries };
+    return { success: false, message: entries.find((e) => e.label === "VCD")?.error ?? "VCD deletion failed", entries };
   }
 
   const allSuccess = entries.every((e) => e.success);

--- a/src/main.ts
+++ b/src/main.ts
@@ -481,8 +481,10 @@ ipcMain.handle("delete-vmc", async (_event, oplRoot: string, name: string) => {
 
 ipcMain.handle(
   "delete-game-and-related-files",
-  async (_event, gamePath: string, artDir: string, gameId: string, launcherFolder?: string) => {
-    return deleteGameAndRelatedFiles(gamePath, artDir, gameId, launcherFolder);
+  async (event, gamePath: string, artDir: string, gameId: string, launcherFolder?: string) => {
+    return deleteGameAndRelatedFiles(gamePath, artDir, gameId, launcherFolder, (entry) => {
+      event.sender.send("delete-ps1-progress", entry);
+    });
   }
 );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -43,7 +43,7 @@ import { checkForUpdates } from "./update.service";
 import { compressIsoToZso } from "./zso.service";
 import { GameCfg, readGameCfg, writeGameCfg } from "./cfg.service";
 import { checkPopsVmc, createVmc, deleteVmc, listVmc } from "./vmc.service";
-import { deleteApp, getApps, getPs1Launchers, importApp, updatePs1TitleCfg } from "./apps.service";
+import { deleteApp, deleteAppWithProgress, getApps, getPs1Launchers, importApp, updatePs1TitleCfg } from "./apps.service";
 import { createLogger, setLogWindow } from "./logger";
 
 const log = createLogger("main");
@@ -459,6 +459,15 @@ ipcMain.handle(
 ipcMain.handle("delete-app", async (_event, oplRoot: string, folder: string) => {
   return deleteApp(oplRoot, folder);
 });
+
+ipcMain.handle(
+  "delete-app-with-progress",
+  async (event, oplRoot: string, folder: string, bootName: string) => {
+    return deleteAppWithProgress(oplRoot, folder, bootName, (entry) => {
+      event.sender.send("delete-app-progress", entry);
+    });
+  }
+);
 
 ipcMain.handle("list-vmc", async (_event, oplRoot: string) => {
   return listVmc(oplRoot);

--- a/src/main.ts
+++ b/src/main.ts
@@ -490,10 +490,10 @@ ipcMain.handle("delete-vmc", async (_event, oplRoot: string, name: string) => {
 
 ipcMain.handle(
   "delete-game-and-related-files",
-  async (event, gamePath: string, artDir: string, gameId: string, launcherFolder?: string) => {
+  async (event, gamePath: string, artDir: string, gameId: string, launcherFolder?: string, bootName?: string) => {
     return deleteGameAndRelatedFiles(gamePath, artDir, gameId, launcherFolder, (entry) => {
       event.sender.send("delete-ps1-progress", entry);
-    });
+    }, bootName);
   }
 );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import {
   shell,
 } from "electron";
 import path from "path";
+import * as fs from "fs/promises";
 import electronReloader from "electron-reloader";
 import PackageInfo from "../package.json";
 import {
@@ -26,6 +27,7 @@ import {
   renameGamefile,
   tryDetermineGameIdFromHex,
   tryDeterminePs1GameIdFromHex,
+  tryDeterminePs1GameIdFromVcd,
 } from "./library.service";
 import { importPs1Game } from "./pops.service";
 import { importPs2CdGame } from "./cd.service";
@@ -38,8 +40,8 @@ import {
 import { checkForUpdates } from "./update.service";
 import { compressIsoToZso } from "./zso.service";
 import { GameCfg, readGameCfg, writeGameCfg } from "./cfg.service";
-import { createVmc, deleteVmc, listVmc } from "./vmc.service";
-import { deleteApp, getApps, importApp } from "./apps.service";
+import { checkPopsVmc, createVmc, deleteVmc, listVmc } from "./vmc.service";
+import { deleteApp, getApps, getPs1Launchers, importApp } from "./apps.service";
 import { createLogger, setLogWindow } from "./logger";
 
 const log = createLogger("main");
@@ -274,10 +276,23 @@ ipcMain.handle(
 
 ipcMain.handle(
   "download-art-by-gameid",
-  async (event, dirPath: string, gameId: string, system?: "PS1" | "PS2") => {
-    return downloadArtByGameId(dirPath, gameId, system || "PS2");
+  async (event, dirPath: string, gameId: string, system?: "PS1" | "PS2", saveAsName?: string) => {
+    return downloadArtByGameId(dirPath, gameId, system || "PS2", saveAsName);
   }
 );
+
+ipcMain.handle("check-art-files-exist", async (_event, artDir: string, filenames: string[]) => {
+  const existing: string[] = [];
+  for (const name of filenames) {
+    try {
+      await fs.access(path.join(artDir, name));
+      existing.push(name);
+    } catch {
+      // File does not exist — skip.
+    }
+  }
+  return existing;
+});
 
 ipcMain.handle("resolve-iso-gameid", async (_event, filepath: string) => {
   return resolveIsoGameId(filepath);
@@ -381,6 +396,14 @@ ipcMain.handle("get-apps", async (_event, oplRoot: string) => {
   return getApps(oplRoot);
 });
 
+ipcMain.handle("get-ps1-launchers", async (_event, oplRoot: string) => {
+  return getPs1Launchers(oplRoot);
+});
+
+ipcMain.handle("try-determine-ps1-gameid-from-vcd", async (_event, filepath: string) => {
+  return tryDeterminePs1GameIdFromVcd(filepath);
+});
+
 ipcMain.handle("open-ask-elf-files", async () => {
   return openAskElfFiles();
 });
@@ -400,6 +423,10 @@ ipcMain.handle("list-vmc", async (_event, oplRoot: string) => {
   return listVmc(oplRoot);
 });
 
+ipcMain.handle("check-pops-vmc", async (_event, oplRoot: string, gameTitle: string) => {
+  return checkPopsVmc(oplRoot, gameTitle);
+});
+
 ipcMain.handle(
   "create-vmc",
   async (_event, oplRoot: string, name: string, sizeMb: number) => {
@@ -413,8 +440,8 @@ ipcMain.handle("delete-vmc", async (_event, oplRoot: string, name: string) => {
 
 ipcMain.handle(
   "delete-game-and-related-files",
-  async (_event, gamePath: string, artDir: string, gameId: string) => {
-    return deleteGameAndRelatedFiles(gamePath, artDir, gameId);
+  async (_event, gamePath: string, artDir: string, gameId: string, launcherFolder?: string) => {
+    return deleteGameAndRelatedFiles(gamePath, artDir, gameId, launcherFolder);
   }
 );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -436,8 +436,8 @@ ipcMain.handle("get-ps1-launchers", async (_event, oplRoot: string) => {
 
 ipcMain.handle(
   "update-ps1-title-cfg",
-  async (_event, launcherPath: string, newTitle: string) => {
-    return updatePs1TitleCfg(launcherPath, newTitle);
+  async (_event, launcherPath: string, newTitle: string, gameId?: string) => {
+    return updatePs1TitleCfg(launcherPath, newTitle, gameId);
   }
 );
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -25,6 +25,8 @@ import {
   openAskGameFiles,
   resolveIsoGameId,
   renameGamefile,
+  renamePs1LauncherStep1,
+  renamePs1LauncherStep2,
   tryDetermineGameIdFromHex,
   tryDeterminePs1GameIdFromHex,
   tryDeterminePs1GameIdFromVcd,
@@ -41,7 +43,7 @@ import { checkForUpdates } from "./update.service";
 import { compressIsoToZso } from "./zso.service";
 import { GameCfg, readGameCfg, writeGameCfg } from "./cfg.service";
 import { checkPopsVmc, createVmc, deleteVmc, listVmc } from "./vmc.service";
-import { deleteApp, getApps, getPs1Launchers, importApp } from "./apps.service";
+import { deleteApp, getApps, getPs1Launchers, importApp, updatePs1TitleCfg } from "./apps.service";
 import { createLogger, setLogWindow } from "./logger";
 
 const log = createLogger("main");
@@ -275,6 +277,38 @@ ipcMain.handle(
 );
 
 ipcMain.handle(
+  "rename-ps1-launcher-step1",
+  async (
+    event,
+    vcdPath: string,
+    gameId: string,
+    newTitle: string
+  ) => {
+    return renamePs1LauncherStep1(vcdPath, gameId, newTitle, (percent, stage) => {
+      event.sender.send("rename-ps1-progress", { percent, stage });
+    });
+  }
+);
+
+ipcMain.handle(
+  "rename-ps1-launcher-step2",
+  async (
+    event,
+    params: {
+      newAppsFolder: string;
+      oldElfFile?: string;
+      newElfFile?: string;
+      newCfgContent?: string;
+      newTitle: string;
+    }
+  ) => {
+    return renamePs1LauncherStep2(params, (percent, stage) => {
+      event.sender.send("rename-ps1-progress", { percent, stage });
+    });
+  }
+);
+
+ipcMain.handle(
   "download-art-by-gameid",
   async (event, dirPath: string, gameId: string, system?: "PS1" | "PS2", saveAsName?: string) => {
     return downloadArtByGameId(dirPath, gameId, system || "PS2", saveAsName);
@@ -399,6 +433,13 @@ ipcMain.handle("get-apps", async (_event, oplRoot: string) => {
 ipcMain.handle("get-ps1-launchers", async (_event, oplRoot: string) => {
   return getPs1Launchers(oplRoot);
 });
+
+ipcMain.handle(
+  "update-ps1-title-cfg",
+  async (_event, launcherPath: string, newTitle: string) => {
+    return updatePs1TitleCfg(launcherPath, newTitle);
+  }
+);
 
 ipcMain.handle("try-determine-ps1-gameid-from-vcd", async (_event, filepath: string) => {
   return tryDeterminePs1GameIdFromVcd(filepath);

--- a/src/pops.service.ts
+++ b/src/pops.service.ts
@@ -149,7 +149,7 @@ export async function importPs1Game(
     await fs.copyFile(popstarterElf, path.join(appsGameDir, elfFilename));
     await fs.writeFile(
       path.join(appsGameDir, "title.cfg"),
-      `title=${gameName}\nboot=${elfFilename}\n`,
+      `title=${gameName}\nboot=${elfFilename}\nGameID=${gameId}\n`,
       "utf-8"
     );
     log.verbose(`Created POPStarter launcher APPS/${appsFolderName}/${elfFilename}`);

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -25,6 +25,25 @@ contextBridge.exposeInMainWorld("libraryAPI", {
       gameName,
       !!nameOnly
     ),
+  renamePs1LauncherStep1: (vcdPath: string, gameId: string, newTitle: string) =>
+    ipcRenderer.invoke("rename-ps1-launcher-step1", vcdPath, gameId, newTitle),
+  renamePs1LauncherStep2: (params: {
+    newAppsFolder: string;
+    oldElfFile?: string;
+    newElfFile?: string;
+    newCfgContent?: string;
+    newTitle: string;
+  }) => ipcRenderer.invoke("rename-ps1-launcher-step2", params),
+  onRenamePs1Progress: (
+    callback: (progress: { percent: number; stage: string }) => void
+  ) => {
+    ipcRenderer.on("rename-ps1-progress", (_event, progress) =>
+      callback(progress)
+    );
+  },
+  removeAllRenamePs1ProgressListeners: () => {
+    ipcRenderer.removeAllListeners("rename-ps1-progress");
+  },
   downloadArtByGameId: (
     dirPath: string,
     gameId: string,
@@ -115,6 +134,8 @@ contextBridge.exposeInMainWorld("libraryAPI", {
   getApps: (oplRoot: string) => ipcRenderer.invoke("get-apps", oplRoot),
   getPs1Launchers: (oplRoot: string) =>
     ipcRenderer.invoke("get-ps1-launchers", oplRoot),
+  updatePs1TitleCfg: (launcherPath: string, newTitle: string) =>
+    ipcRenderer.invoke("update-ps1-title-cfg", launcherPath, newTitle),
   openAskElfFiles: () => ipcRenderer.invoke("open-ask-elf-files"),
   importApp: (oplRoot: string, elfPath: string, title: string) =>
     ipcRenderer.invoke("import-app", oplRoot, elfPath, title),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -134,8 +134,8 @@ contextBridge.exposeInMainWorld("libraryAPI", {
   getApps: (oplRoot: string) => ipcRenderer.invoke("get-apps", oplRoot),
   getPs1Launchers: (oplRoot: string) =>
     ipcRenderer.invoke("get-ps1-launchers", oplRoot),
-  updatePs1TitleCfg: (launcherPath: string, newTitle: string) =>
-    ipcRenderer.invoke("update-ps1-title-cfg", launcherPath, newTitle),
+  updatePs1TitleCfg: (launcherPath: string, newTitle: string, gameId?: string) =>
+    ipcRenderer.invoke("update-ps1-title-cfg", launcherPath, newTitle, gameId),
   openAskElfFiles: () => ipcRenderer.invoke("open-ask-elf-files"),
   importApp: (oplRoot: string, elfPath: string, title: string) =>
     ipcRenderer.invoke("import-app", oplRoot, elfPath, title),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -28,8 +28,11 @@ contextBridge.exposeInMainWorld("libraryAPI", {
   downloadArtByGameId: (
     dirPath: string,
     gameId: string,
-    system?: "PS1" | "PS2"
-  ) => ipcRenderer.invoke("download-art-by-gameid", dirPath, gameId, system),
+    system?: "PS1" | "PS2",
+    saveAsName?: string
+  ) => ipcRenderer.invoke("download-art-by-gameid", dirPath, gameId, system, saveAsName),
+  checkArtFilesExist: (artDir: string, filenames: string[]) =>
+    ipcRenderer.invoke("check-art-files-exist", artDir, filenames),
   tryDetermineGameIdFromHex: (filepath: string) =>
     ipcRenderer.invoke("try-determine-gameid-from-hex", filepath),
   resolveIsoGameId: (filepath: string) =>
@@ -38,6 +41,8 @@ contextBridge.exposeInMainWorld("libraryAPI", {
     ipcRenderer.invoke("open-ask-game-files", isGameCd, isGameDvd),
   tryDeterminePs1GameIdFromHex: (filepath: string) =>
     ipcRenderer.invoke("try-determine-ps1-gameid-from-hex", filepath),
+  tryDeterminePs1GameIdFromVcd: (filepath: string) =>
+    ipcRenderer.invoke("try-determine-ps1-gameid-from-vcd", filepath),
   importPs1Game: (
     cueFilePath: string,
     oplRoot: string,
@@ -108,12 +113,16 @@ contextBridge.exposeInMainWorld("libraryAPI", {
     ipcRenderer.removeAllListeners("zso-compress-progress");
   },
   getApps: (oplRoot: string) => ipcRenderer.invoke("get-apps", oplRoot),
+  getPs1Launchers: (oplRoot: string) =>
+    ipcRenderer.invoke("get-ps1-launchers", oplRoot),
   openAskElfFiles: () => ipcRenderer.invoke("open-ask-elf-files"),
   importApp: (oplRoot: string, elfPath: string, title: string) =>
     ipcRenderer.invoke("import-app", oplRoot, elfPath, title),
   deleteApp: (oplRoot: string, folder: string) =>
     ipcRenderer.invoke("delete-app", oplRoot, folder),
   listVmc: (oplRoot: string) => ipcRenderer.invoke("list-vmc", oplRoot),
+  checkPopsVmc: (oplRoot: string, gameTitle: string) =>
+    ipcRenderer.invoke("check-pops-vmc", oplRoot, gameTitle),
   createVmc: (oplRoot: string, name: string, sizeMb: number) =>
     ipcRenderer.invoke("create-vmc", oplRoot, name, sizeMb),
   deleteVmc: (oplRoot: string, name: string) =>
@@ -128,13 +137,15 @@ contextBridge.exposeInMainWorld("libraryAPI", {
   deleteGameAndRelatedFiles: (
     gamePath: string,
     artDir: string,
-    gameId: string
+    gameId: string,
+    launcherFolder?: string
   ) =>
     ipcRenderer.invoke(
       "delete-game-and-related-files",
       gamePath,
       artDir,
-      gameId
+      gameId,
+      launcherFolder
     ),
   moveFile: (sourcePath: string, destPath: string) =>
     ipcRenderer.invoke("move-file", sourcePath, destPath),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -44,6 +44,14 @@ contextBridge.exposeInMainWorld("libraryAPI", {
   removeAllRenamePs1ProgressListeners: () => {
     ipcRenderer.removeAllListeners("rename-ps1-progress");
   },
+  onDeletePs1Progress: (
+    callback: (entry: { label: string; path?: string; success: boolean; error?: string }) => void
+  ) => {
+    ipcRenderer.on("delete-ps1-progress", (_event, entry) => callback(entry));
+  },
+  removeAllDeletePs1ProgressListeners: () => {
+    ipcRenderer.removeAllListeners("delete-ps1-progress");
+  },
   downloadArtByGameId: (
     dirPath: string,
     gameId: string,

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -149,6 +149,16 @@ contextBridge.exposeInMainWorld("libraryAPI", {
     ipcRenderer.invoke("import-app", oplRoot, elfPath, title),
   deleteApp: (oplRoot: string, folder: string) =>
     ipcRenderer.invoke("delete-app", oplRoot, folder),
+  deleteAppWithProgress: (oplRoot: string, folder: string, bootName: string) =>
+    ipcRenderer.invoke("delete-app-with-progress", oplRoot, folder, bootName),
+  onDeleteAppProgress: (
+    callback: (entry: { label: string; path?: string; success: boolean; error?: string }) => void
+  ) => {
+    ipcRenderer.on("delete-app-progress", (_event, entry) => callback(entry));
+  },
+  removeAllDeleteAppProgressListeners: () => {
+    ipcRenderer.removeAllListeners("delete-app-progress");
+  },
   listVmc: (oplRoot: string) => ipcRenderer.invoke("list-vmc", oplRoot),
   checkPopsVmc: (oplRoot: string, gameTitle: string) =>
     ipcRenderer.invoke("check-pops-vmc", oplRoot, gameTitle),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -177,14 +177,16 @@ contextBridge.exposeInMainWorld("libraryAPI", {
     gamePath: string,
     artDir: string,
     gameId: string,
-    launcherFolder?: string
+    launcherFolder?: string,
+    bootName?: string
   ) =>
     ipcRenderer.invoke(
       "delete-game-and-related-files",
       gamePath,
       artDir,
       gameId,
-      launcherFolder
+      launcherFolder,
+      bootName
     ),
   moveFile: (sourcePath: string, destPath: string) =>
     ipcRenderer.invoke("move-file", sourcePath, destPath),

--- a/src/vmc.service.ts
+++ b/src/vmc.service.ts
@@ -36,6 +36,30 @@ function vmcDir(oplRoot: string): string {
   return path.join(oplRoot, "VMC");
 }
 
+/**
+ * Check for per-game POPStarter VMC files in POPS/<subfolder>/.
+ * POPStarter stores VMCs as SLOT0.VMC / SLOT1.VMC (or .bin) inside a
+ * subfolder named after the game, directly under the POPS directory at
+ * the device root — NOT under VMC/POPS/.
+ */
+export async function checkPopsVmc(
+  oplRoot: string,
+  subfolder: string
+): Promise<{ success: boolean; slot0: string | null; slot1: string | null }> {
+  try {
+    const dir = path.join(oplRoot, "POPS", subfolder);
+    // Accept .VMC or .bin — both are used by POPStarter setups
+    const files = await fs.readdir(dir).catch(() => []);
+    const slot0 = files.find((f) => /^SLOT0\.(VMC|BIN)$/i.test(f)) ?? null;
+    const slot1 = files.find((f) => /^SLOT1\.(VMC|BIN)$/i.test(f)) ?? null;
+    log.verbose(`POPS VMC check for "${subfolder}": slot0="${slot0}", slot1="${slot1}" (dir=${dir})`);
+    return { success: true, slot0, slot1 };
+  } catch (err: any) {
+    log.verbose(`POPS VMC check for "${subfolder}" failed: ${err?.message || err}`);
+    return { success: false, slot0: null, slot1: null };
+  }
+}
+
 export async function listVmc(
   oplRoot: string
 ): Promise<{ success: boolean; cards: VmcInfo[]; message?: string }> {


### PR DESCRIPTION
## Description

Currently, the OrbitOPL does not offer full or proper support for displaying `ELF` apps and `PS1` games within the Apps section (for OPL versions 1.2+), nor does it provide the option to manage these lists using OrbitOPL features; furthermore, due to their file structure and naming, these `PS1` games are erroneously categorized under **`Invalid Files`** section as OrbitOPL expects them to follow a naming convention that they do not actually use.

This feature adds the necessary functionality and makes the appropriate adjustments to improve the display and management of this section.

This applies primarily to `PS1` games that have been integrated into the APPS section and follow this structure and which has several files distributed between the `APPS` and `POPS` folders:

> [!NOTE]  
> This is the type of structure it handles easily, and it is created by applications such as [**`POPS VCD MANAGER`**](https://www.psx-place.com/resources/pops-vcd-manager.1284/?__cf_chl_rt_tk=FZOwyuqF8xXH3LU4zwlMdKGRizZKF4_oEF211tizOTM-1782445609-1.0.1.1-hw_kNjfgURn8fe70fIOsi4_M5C5wuabkLlMkS._l1Qs).

```
DEVICE/
├── APPS/
│   └── POPS_GAME_NAME/
│       ├── title.cfg
│       └── XX.GAME_NAME.ELF
└── POPS/
    ├── GAME_NAME/
    │   ├── CHEATS.TXT
    │   ├── SLOT0.VMC
    │   └── SLOT1.VMC
    └── GAME_NAME.VCD
```
and also for the `ELF` applications hosted in the `APPS` directory, which has the following file structure

```
DEVICE/
└── APPS/
    └── APPLICATION_NAME/
        ├── title.cfg
        └── APPLICATION_NAME.ELF
```

💡 This is the initial phase, adding support for improved visualization and management of `PS1` games and `ELF` apps in the `Apps` section; the next phase will involve adding more options to this section.

## Type of Change

- [x] New feature
- [x] Refactoring (small enhancements)

## Summary
- Support was added to correctly display `ELF` applications and `PS1` games hosted in the `APPS` section of the list.
- Visual adjustments to the `APPS` section Grid and List for the proper display of games and apps.
- The Tags for elements in the `APPS` grid and list were adjusted, and the tags for `ELF` applications were modified to display their format.
- Logic adjustments to correctly detect `PS1` games in the Apps section, including conditions to prevent them from being flagged as **`Invalid Files`**; conditions were added to detect the `GameID` from the `title.cfg` file in cases where it cannot be retrieved from the `.VCD` file.
- Logic adjustments in the `APPS` section to correctly detect Artwork, considering the naming conventions for `ELF` applications  and `PS1` games in this section.
- **Fetch Artwork**
  - Adjustments were made to the logic so that the existing Artwork download functionality would work correctly with `PS1` games in the Apps section.
  - Status messages for the Artwork download functionality were improved.
- **Game Settings**
  -  This section was modified to align with the `PS1` Games in the Apps section, as certain incompatible features specific to `PS2` games were still appearing in these settings.
  - The `Display Title Override` functionality has been improved to allow modifying the `PS1` game title in the list; this changes only the title on list, not the filenames (the user is also notified of this).
- **Rename PS1 Games workflow**
  - A detailed workflow was added to preview which files and directories will be modified with the new name to be assigned.
  - Once the process completes successfully, a dialog will be displayed to the user containing a detailed log of all files and directories modified by the rename operation.
- **Delete PS1 Games and ELF applications workflow:**
  - The workflow been improved by adding a confirmation dialog to prevent accidental deletions, and an option has been added to choose whether or not to delete associated Artwork.
  - A dialog message was added to display a list of deleted files and directories upon completion of the process, thereby improving interaction.
- **General code improvements**
  - Various code improvements and optimizations were implemented to enhance performance and make cross-platform compatibility adjustments.


## Screenshots

### Grid View

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 202704" src="https://github.com/user-attachments/assets/0f3190ac-9fbb-4bc6-807e-90fbcd9b88e2" />

### List View

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 202725" src="https://github.com/user-attachments/assets/79555b5e-139d-4002-99c7-fe5f0bf64305" />

### Available Settings for PS1 Games

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 202753" src="https://github.com/user-attachments/assets/10a2d9ac-01cd-4153-b41f-1068dd6562bd" />

### Fetch Artwork

- If game-related assets have already been detected in the `ART` directory, the user will be asked whether they wish to overwrite the files instead of downloading them automatically.

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 202912" src="https://github.com/user-attachments/assets/932c9762-15c5-4021-bba6-462a95fae061" />

- In the "**Import Jobs**" section, status messages regarding the download of Artwork have been improved; the system now displays the appropriate messages and colors depending on: whether the assets were successfully downloaded or overwritten, the download was cancelled, or no assets were found for the corresponding game.

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 203023" src="https://github.com/user-attachments/assets/08370bb4-596a-4c94-9455-7b91eb74858d" />

### Game Settings

For this section, the only options currently displayed are changing the display name (the one that appears in the OPL list and within this application, has a condition to prevent empty text for Display name) and viewing the details of the assigned VMCs (for now, they cannot be edited or created).

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 203128" src="https://github.com/user-attachments/assets/aa56445e-6eee-4de7-8cb5-f524e932bf37" />

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 203153" src="https://github.com/user-attachments/assets/477f2fb8-f59d-4862-9447-eda6a59bd04f" />


### Rename Game

The third option in the Settings menu provides a complete workflow for renaming game-related files within the APPS section (which follow a specific structure, as shown in Description).

- When a change in the name field is detected, the user will be informed which files and folders are to be renamed.

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 203220" src="https://github.com/user-attachments/assets/2014d82d-d00f-48f3-9e09-1e061b5671d3" />

- Validation was also added to prevent empty text.

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 203229" src="https://github.com/user-attachments/assets/daec2f4f-4165-456f-8263-40a451256631" />

- Once the rename process is complete, the user will be shown a detailed log of the renamed items, and the changes will already be reflected in the list.

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 203518" src="https://github.com/user-attachments/assets/7509ef3d-8099-49d9-ab51-407a8c5cdefe" />

### Delete Game

The workflow for Delete PS1 Games has been improved; conditions have been added to the confirmation dialog, along with an option to choose whether or not to delete the artwork associated with the game.

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 203622" src="https://github.com/user-attachments/assets/28abf132-1307-42b2-937a-48168800701e" />

- When deleting a PS1 game in the `APPS` section, several items will be removed; once the process is complete, the user will be shown which files and folders were deleted (items from the `ART` folder will also be listed if that option was selected), and the changes should be reflected in the list (and on the device).

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 203710" src="https://github.com/user-attachments/assets/1e537375-b0cc-4116-a844-43fe2c83f44b" />

### Delete App

This is the only option available (for now) for the Apps section.

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 203745" src="https://github.com/user-attachments/assets/fcaea5ee-0de7-40f3-95cb-cd2935ea2f79" />

- When the user selects the option to delete an app, a confirmation message will be displayed, along with the option to delete the corresponding assets.

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 203757" src="https://github.com/user-attachments/assets/29efbd0c-4c5f-4018-a0e2-340bda574ad8" />

- When the process finishes, the user is shown a list of the deleted files and folders (items from the ART directory will be included if that option was selected).

<img width="1615" height="889" alt="Captura de pantalla 2026-06-25 203810" src="https://github.com/user-attachments/assets/382b50c3-1d38-4a9b-971c-1909de8ee3eb" />

