### PR TITLE
chore: title bar fixes and improvements

### DIFF
--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -29,23 +29,20 @@ export class AppComponent {
   constructor(
     private readonly _logger: LogsService,
     public readonly _libraryService: LibraryService,
-    public readonly _updateService: UpdateService
-  ) { }
+    public readonly _updateService: UpdateService,
+  ) {}
 
   ngOnInit() {
     const os = window.navigator.platform;
 
     this._logger.log(
       'AppComponent',
-      `App initialized (${BuildInfo.version}) [OS: ${os}]`
+      `App initialized (${BuildInfo.version}) [OS: ${os}]`,
     );
 
     window.windowAPI.wmInfo().then((info) => {
       if (info.name) {
-        this._logger.log(
-          'AppComponent',
-          `Desktop environment: ${info.name}`
-        );
+        this._logger.log('AppComponent', `Desktop environment: ${info.name}`);
       }
     });
 

--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -30,7 +30,7 @@ export class AppComponent {
     private readonly _logger: LogsService,
     public readonly _libraryService: LibraryService,
     public readonly _updateService: UpdateService
-  ) {}
+  ) { }
 
   ngOnInit() {
     const os = window.navigator.platform;
@@ -39,6 +39,16 @@ export class AppComponent {
       'AppComponent',
       `App initialized (${PackageInfo.version}) [OS: ${os}]`
     );
+
+    window.windowAPI.wmInfo().then((info) => {
+      console.log('Window Manager Info:', info);
+      if (info.name) {
+        this._logger.log(
+          'AppComponent',
+          `Desktop environment: ${info.name}`
+        );
+      }
+    });
 
     this._libraryService.restoreLastDirectory();
 

--- a/angular/src/app/app.component.ts
+++ b/angular/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
 import { LogsService } from './shared/services/logs.service';
-import PackageInfo from '../../../package.json';
+import { BuildInfo } from './shared/build-info';
 import { LibraryService } from './shared/services/library.service';
 import { AsyncPipe } from '@angular/common';
 import { LucideAngularModule } from 'lucide-angular';
@@ -25,7 +25,7 @@ import { UpdateService } from './shared/services/update.service';
 })
 export class AppComponent {
   public currentDirectory = 'None';
-  public readonly version = PackageInfo.version;
+  public readonly version = BuildInfo.version;
   constructor(
     private readonly _logger: LogsService,
     public readonly _libraryService: LibraryService,
@@ -37,11 +37,10 @@ export class AppComponent {
 
     this._logger.log(
       'AppComponent',
-      `App initialized (${PackageInfo.version}) [OS: ${os}]`
+      `App initialized (${BuildInfo.version}) [OS: ${os}]`
     );
 
     window.windowAPI.wmInfo().then((info) => {
-      console.log('Window Manager Info:', info);
       if (info.name) {
         this._logger.log(
           'AppComponent',

--- a/angular/src/app/pages/details/details.component.ts
+++ b/angular/src/app/pages/details/details.component.ts
@@ -1,4 +1,4 @@
-import { ApplicationRef, Component, inject } from '@angular/core';
+import { ChangeDetectorRef, Component, inject } from '@angular/core';
 import { Router } from '@angular/router';
 import { LucideAngularModule } from 'lucide-angular';
 import { LibraryService } from '@shared/services/library.service';
@@ -22,9 +22,9 @@ import { Game, gameArt } from '@shared/types/game.type';
  *
  * ── Change detection ──────────────────────────────────────────────
  * Uses `ChangeDetectionStrategy.Default` and calls
- * `ApplicationRef.tick()` after every async state assignment because
- * zone.js cannot reliably track Promise microtasks across Electron's
- * `contextBridge` boundary.
+ * `ChangeDetectorRef.detectChanges()` after every async state assignment
+ * because zone.js cannot reliably track Promise microtasks across
+ * Electron's `contextBridge` boundary.
  */
 @Component({
   selector: 'app-details',
@@ -38,7 +38,7 @@ export class DetailsComponent {
   private _library = inject(LibraryService);
   private _cfg = inject(CfgService);
   private _titleCfg = inject(TitleCfgService);
-  private _appRef = inject(ApplicationRef);
+  private _cdr = inject(ChangeDetectorRef);
 
   // ── Component state ───────────────────────────────────────────
 
@@ -81,7 +81,7 @@ export class DetailsComponent {
 
     if (!this.game) {
       this.loading = false;
-      this._appRef.tick();
+      this._cdr.detectChanges();
       return;
     }
 
@@ -99,13 +99,13 @@ export class DetailsComponent {
         });
     }
 
-    // ── Async metadata — fire-and-forget via .then() + ApplicationRef.tick() ──
+    // ── Async metadata — fire-and-forget via .then() + detectChanges() ──
     const root = this._library.currentDirectoryValue;
     if (root) {
       this._loadMetadata(root);
     } else {
       this.loading = false;
-      this._appRef.tick();
+      this._cdr.detectChanges();
     }
   }
 
@@ -120,7 +120,7 @@ export class DetailsComponent {
    * 3. **ELF homebrew** → `title.cfg` (with field restrictions)
    *
    * Every `.then()` callback assigns state directly and calls
-   * `ApplicationRef.tick()` to force Angular change detection,
+   * `ChangeDetectorRef.detectChanges()` to force Angular change detection,
    * bypassing zone.js microtask tracking (which Electron's
    * `contextBridge` cannot reliably trigger).
    */
@@ -142,11 +142,11 @@ export class DetailsComponent {
         this.players = cfg['PlayersText'] || cfg['Players'] || '';
         this._applyFallbackTitle();
         this.loading = false;
-        this._appRef.tick();
+        this._cdr.detectChanges();
       }).catch(() => {
         this._applyFallbackTitle();
         this.loading = false;
-        this._appRef.tick();
+        this._cdr.detectChanges();
       });
       return;
     }
@@ -163,7 +163,7 @@ export class DetailsComponent {
 
     this._applyFallbackTitle();
     this.loading = false;
-    this._appRef.tick();
+    this._cdr.detectChanges();
   }
 
   /**
@@ -186,7 +186,7 @@ export class DetailsComponent {
       if (data.playersText) this.players = data.playersText;
       this._applyFallbackTitle();
       this.loading = false;
-      this._appRef.tick();
+      this._cdr.detectChanges();
     });
   }
 

--- a/angular/src/app/shared/components/title-bar/title-bar.component.html
+++ b/angular/src/app/shared/components/title-bar/title-bar.component.html
@@ -1,36 +1,27 @@
 @if (visible) {
 <div class="title-bar glass-strong flex h-9 items-center relative z-40 select-none">
-  <div class="drag-region flex flex-1 items-center gap-2 px-3 h-full" (dblclick)="maximizeToggle()">
+  <div class="drag-region flex flex-1 items-center gap-2 px-3 h-full" (dblclick)="canMaximize && maximizeToggle()">
     <img src="icon.svg" alt="" class="h-4 w-4" />
-    <span class="font-display text-xs font-semibold tracking-wide text-base-content/70"
-      >OrbitOPL Toolbox <span class="text-base-content/35">v{{ version }}</span></span
-    >
+    <span class="font-display text-xs font-semibold tracking-wide text-base-content/70">OrbitOPL Toolbox <span
+        class="text-base-content/35">v{{ version }}</span></span>
   </div>
 
   <div class="window-controls flex h-full items-stretch">
-    <button
-      class="win-btn"
-      title="Minimize"
-      (click)="minimize()"
-    >
+    @if (canMinimize) {
+    <button class="win-btn" title="Minimize" (click)="minimize()">
       <i-lucide name="minus" size="15"></i-lucide>
     </button>
-    <button
-      class="win-btn"
-      [title]="maximized ? 'Restore' : 'Maximize'"
-      (click)="maximizeToggle()"
-    >
+    }
+    @if (canMaximize) {
+    <button class="win-btn" [title]="maximized ? 'Restore' : 'Maximize'" (click)="maximizeToggle()">
       @if (maximized) {
       <i-lucide name="copy" size="13" class="-scale-x-100"></i-lucide>
       } @else {
       <i-lucide name="square" size="13"></i-lucide>
       }
     </button>
-    <button
-      class="win-btn win-btn-close"
-      title="Close"
-      (click)="close()"
-    >
+    }
+    <button class="win-btn win-btn-close" title="Close" (click)="close()">
       <i-lucide name="x" size="15"></i-lucide>
     </button>
   </div>

--- a/angular/src/app/shared/components/title-bar/title-bar.component.ts
+++ b/angular/src/app/shared/components/title-bar/title-bar.component.ts
@@ -1,6 +1,6 @@
-import { Component, DestroyRef, ChangeDetectorRef, inject, OnInit } from '@angular/core';
+import { ChangeDetectorRef, Component, DestroyRef, inject, OnInit } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
-import PackageInfo from '../../../../../../package.json';
+import { BuildInfo } from '../../build-info';
 
 @Component({
   selector: 'app-title-bar',
@@ -11,29 +11,27 @@ import PackageInfo from '../../../../../../package.json';
 export class TitleBarComponent implements OnInit {
   private readonly _destroyRef = inject(DestroyRef);
   private readonly _cdr = inject(ChangeDetectorRef);
-  public readonly version = PackageInfo.version;
+  public readonly version = BuildInfo.version;
   public visible = false;
   public maximized = false;
   public canMinimize = false;
   public canMaximize = false;
 
   ngOnInit() {
-    window.windowAPI.platform().then((platform) => {
+    void Promise.all([
+      window.windowAPI.platform(),
+      window.windowAPI.canWindowControls(),
+      window.windowAPI.isMaximized(),
+    ]).then(([platform, { canMinimize, canMaximize }, maximized]) => {
       // macOS keeps its native frame/traffic lights; only draw our own
       // title bar where the main process created a frameless window.
       this.visible = platform !== 'darwin';
-      this._cdr.detectChanges();
-    });
-
-    window.windowAPI.canWindowControls().then(({ canMinimize, canMaximize }) => {
       this.canMinimize = canMinimize;
       this.canMaximize = canMaximize;
+      this.maximized = maximized;
       this._cdr.detectChanges();
     });
 
-    window.windowAPI.isMaximized().then((isMaximized) => {
-      this.maximized = isMaximized;
-    });
     window.windowAPI.onMaximizedChange((isMaximized) => {
       this.maximized = isMaximized;
       this._cdr.detectChanges();

--- a/angular/src/app/shared/components/title-bar/title-bar.component.ts
+++ b/angular/src/app/shared/components/title-bar/title-bar.component.ts
@@ -1,4 +1,4 @@
-import { Component, DestroyRef, inject, OnInit } from '@angular/core';
+import { Component, DestroyRef, ChangeDetectorRef, inject, OnInit } from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import PackageInfo from '../../../../../../package.json';
 
@@ -9,15 +9,26 @@ import PackageInfo from '../../../../../../package.json';
   styleUrl: './title-bar.component.scss',
 })
 export class TitleBarComponent implements OnInit {
+  private readonly _destroyRef = inject(DestroyRef);
+  private readonly _cdr = inject(ChangeDetectorRef);
   public readonly version = PackageInfo.version;
   public visible = false;
   public maximized = false;
+  public canMinimize = false;
+  public canMaximize = false;
 
   ngOnInit() {
     window.windowAPI.platform().then((platform) => {
       // macOS keeps its native frame/traffic lights; only draw our own
       // title bar where the main process created a frameless window.
       this.visible = platform !== 'darwin';
+      this._cdr.detectChanges();
+    });
+
+    window.windowAPI.canWindowControls().then(({ canMinimize, canMaximize }) => {
+      this.canMinimize = canMinimize;
+      this.canMaximize = canMaximize;
+      this._cdr.detectChanges();
     });
 
     window.windowAPI.isMaximized().then((isMaximized) => {
@@ -25,10 +36,10 @@ export class TitleBarComponent implements OnInit {
     });
     window.windowAPI.onMaximizedChange((isMaximized) => {
       this.maximized = isMaximized;
+      this._cdr.detectChanges();
     });
 
-    const destroyRef = inject(DestroyRef);
-    destroyRef.onDestroy(() =>
+    this._destroyRef.onDestroy(() =>
       window.windowAPI.removeAllMaximizedChangeListeners()
     );
   }

--- a/angular/src/app/shared/components/title-bar/title-bar.component.ts
+++ b/angular/src/app/shared/components/title-bar/title-bar.component.ts
@@ -1,4 +1,10 @@
-import { ChangeDetectorRef, Component, DestroyRef, inject, OnInit } from '@angular/core';
+import {
+  ChangeDetectorRef,
+  Component,
+  DestroyRef,
+  inject,
+  OnInit,
+} from '@angular/core';
 import { LucideAngularModule } from 'lucide-angular';
 import { BuildInfo } from '../../build-info';
 
@@ -38,7 +44,7 @@ export class TitleBarComponent implements OnInit {
     });
 
     this._destroyRef.onDestroy(() =>
-      window.windowAPI.removeAllMaximizedChangeListeners()
+      window.windowAPI.removeAllMaximizedChangeListeners(),
     );
   }
 

--- a/angular/src/app/window.d.ts
+++ b/angular/src/app/window.d.ts
@@ -369,6 +369,9 @@ declare interface Window {
     /** Node's `process.platform` for the main process (e.g. 'win32', 'linux', 'darwin'). */
     platform: () => Promise<NodeJS.Platform>;
 
+    /** Whether the platform WM supports minimize and maximize (false on tiling WMs). */
+    canWindowControls: () => Promise<{ canMinimize: boolean; canMaximize: boolean }>;
+
     /** Minimize the current window. */
     minimize: () => void;
 

--- a/angular/src/app/window.d.ts
+++ b/angular/src/app/window.d.ts
@@ -372,6 +372,9 @@ declare interface Window {
     /** Whether the platform WM supports minimize and maximize (false on tiling WMs). */
     canWindowControls: () => Promise<{ canMinimize: boolean; canMaximize: boolean }>;
 
+    /** Detected desktop environment or window manager on Linux (empty on other platforms). */
+    wmInfo: () => Promise<{ name: string; env: Record<string, string> }>;
+
     /** Minimize the current window. */
     minimize: () => void;
 

--- a/src/ipc/window.ipc.ts
+++ b/src/ipc/window.ipc.ts
@@ -1,7 +1,50 @@
 import { ipcMain, BrowserWindow } from "electron";
 
+const TILING_WMS = [
+  "i3",
+  "sway",
+  "hyprland",
+  "bspwm",
+  "awesome",
+  "xmonad",
+  "dwm",
+  "herbstluftwm",
+  "qtile",
+  "river",
+  "labwc",
+  "niri",
+];
+
+function detectWindowControls(): { canMinimize: boolean; canMaximize: boolean } {
+  if (process.platform !== "linux") {
+    return { canMinimize: true, canMaximize: true };
+  }
+
+  const envVars = [
+    process.env.XDG_CURRENT_DESKTOP ?? "",
+    process.env.DESKTOP_SESSION ?? "",
+    process.env.XDG_SESSION_DESKTOP ?? "",
+    process.env.GDMSESSION ?? "",
+  ];
+
+  const segments = envVars
+    .flatMap((v) => v.toLowerCase().split(":"))
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  const isTiling = segments.some((seg) =>
+    TILING_WMS.includes(seg)
+  );
+
+  return isTiling
+    ? { canMinimize: false, canMaximize: false }
+    : { canMinimize: true, canMaximize: true };
+}
+
 export function registerWindowIpc(): void {
   ipcMain.handle("window-platform", () => process.platform);
+
+  ipcMain.handle("window-can-window-controls", () => detectWindowControls());
 
   ipcMain.on("window-minimize", (event) => {
     BrowserWindow.fromWebContents(event.sender)?.minimize();

--- a/src/ipc/window.ipc.ts
+++ b/src/ipc/window.ipc.ts
@@ -41,10 +41,42 @@ function detectWindowControls(): { canMinimize: boolean; canMaximize: boolean } 
     : { canMinimize: true, canMaximize: true };
 }
 
+function detectWmInfo(): { name: string; env: Record<string, string> } {
+  if (process.platform !== "linux") {
+    return { name: "", env: {} };
+  }
+
+  const env: Record<string, string> = {
+    XDG_CURRENT_DESKTOP: process.env.XDG_CURRENT_DESKTOP ?? "",
+    DESKTOP_SESSION: process.env.DESKTOP_SESSION ?? "",
+    XDG_SESSION_DESKTOP: process.env.XDG_SESSION_DESKTOP ?? "",
+    GDMSESSION: process.env.GDMSESSION ?? "",
+  };
+
+  const candidates = [
+    env.XDG_CURRENT_DESKTOP,
+    env.XDG_SESSION_DESKTOP,
+    env.DESKTOP_SESSION,
+    env.GDMSESSION,
+  ];
+
+  let name = "";
+  for (const candidate of candidates) {
+    if (candidate) {
+      name = candidate.split(":")[0].trim();
+      break;
+    }
+  }
+
+  return { name, env };
+}
+
 export function registerWindowIpc(): void {
   ipcMain.handle("window-platform", () => process.platform);
 
   ipcMain.handle("window-can-window-controls", () => detectWindowControls());
+
+  ipcMain.handle("window-wm-info", () => detectWmInfo());
 
   ipcMain.on("window-minimize", (event) => {
     BrowserWindow.fromWebContents(event.sender)?.minimize();

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -300,6 +300,7 @@ function buildWindowAPI() {
   return {
     platform: () => ipcRenderer.invoke("window-platform"),
     canWindowControls: () => ipcRenderer.invoke("window-can-window-controls"),
+    wmInfo: () => ipcRenderer.invoke("window-wm-info"),
     minimize: () => ipcRenderer.send("window-minimize"),
     maximizeToggle: () => ipcRenderer.send("window-maximize-toggle"),
     close: () => ipcRenderer.send("window-close"),

--- a/src/preload.ts
+++ b/src/preload.ts
@@ -299,6 +299,7 @@ function buildLibraryAPI() {
 function buildWindowAPI() {
   return {
     platform: () => ipcRenderer.invoke("window-platform"),
+    canWindowControls: () => ipcRenderer.invoke("window-can-window-controls"),
     minimize: () => ipcRenderer.send("window-minimize"),
     maximizeToggle: () => ipcRenderer.send("window-maximize-toggle"),
     close: () => ipcRenderer.send("window-close"),


### PR DESCRIPTION
# Description

The application's new custom title bar has some functional issues regarding the window maximize and restore states, which are not being reflected correctly.

<img width="960" height="540" alt="ISSUE-maximizeandrestore-ezgif com-optimize" src="https://github.com/user-attachments/assets/9d8b838b-7a96-4966-9603-10f22b27eca1" />


Additionally, the **`Linux`** version does not currently consider the specific desktop environment; consequently, systems using Tiling Window Managers (such as `i3`, `sway`, `Hyprland`, etc.) display `minimize` and `maximize` buttons, even though those options are often unusable in such environments—where typically only the "`close`" function is available.

# Type of change
- [ ] New feature
- [x] Refactoring (code improvement and fix) 

# Summary

Fixes three runtime bugs in the title bar and details view, adds support for Linux tiling window managers, and cleans up app version handling between the Electron and Angular layers.

### Changes

**Title bar fixes (`title-bar.component.ts`)**
- Fix `NG0203`: moved `inject(DestroyRef)`/`ChangeDetectorRef` out of `ngOnInit` into field initializers (valid injection context).
- Fix inverted maximize/restore icon: Electron's `ipcRenderer.on` callbacks run outside Angular's Zone, so `detectChanges()` is now called in `onMaximizedChange`.
- Consolidated the async init (`platform()`, `canWindowControls()`, `isMaximized()`) into a single `Promise.all` with one `detectChanges()` call, removing redundant change-detection cycles.

**Linux tiling WM support (`src/ipc/window.ipc.ts`, `preload.ts`, `window.d.ts`)**
- New IPC handlers `window-can-window-controls` and `window-wm-info` with env-var detection (`XDG_CURRENT_DESKTOP`, `DESKTOP_SESSION`, `XDG_SESSION_DESKTOP`, `GDMSESSION`) against a `TILING_WMS` list (i3, sway, Hyprland, etc.).
- Exposed as `windowAPI.canWindowControls()` / `wmInfo()` through the preload bridge and typed in `window.d.ts`.
- Title bar hides minimize/maximize buttons on tiling WMs (`@if (canMinimize)` / `@if (canMaximize)`), keeps close always visible, and guards the double-click-to-maximize on the drag region.

**Version handling (best practices between layers)**
- Renderer now uses the auto-generated `shared/build-info.ts` (`BuildInfo.version`) instead of importing the root `package.json` into the bundle (removes full JSON from the renderer output, fixes fragile deep relative imports). Electron layer keeps its runtime `require("../package.json")` (no bundling, packaged via `build.files`).

**Details view fix (`details.component.ts`)**
- Fix `NG0101` recursion: replaced app-wide `ApplicationRef.tick()` with component-local `ChangeDetectorRef.detectChanges()` (6 call sites).

**Startup logging (`app.component.ts`)**
- Logs the detected desktop environment/WM on Linux via `wmInfo()`.

### Files modified
| File | Change |
|---|---|
| `src/ipc/window.ipc.ts` | Tiling-WM + WM-info detection, 2 new IPC handlers |
| `src/preload.ts` | `canWindowControls`, `wmInfo` in `windowAPI` |
| `angular/src/app/window.d.ts` | Types for the new `windowAPI` methods |
| `angular/src/app/shared/components/title-bar/title-bar.component.ts` | NG0203 fix, Zone-safe CD, `Promise.all` init, `BuildInfo` version, `canMinimize`/`canMaximize` flags |
| `angular/src/app/shared/components/title-bar/title-bar.component.html` | Conditional window controls + guarded dblclick |
| `angular/src/app/pages/details/details.component.ts` | `ApplicationRef.tick()` → `ChangeDetectorRef.detectChanges()` (NG0101 fix) |
| `angular/src/app/app.component.ts` | `BuildInfo` version, DE/WM startup log |
****

# Screenshots

#### Fixed Maximize/Restore Behavior
<img width="1920" height="1080" alt="maximizeandrestore-ezgif com-optimize" src="https://github.com/user-attachments/assets/9a2865e9-dd76-4d4c-b8b5-f03d9a94ce93" />
